### PR TITLE
drag and drop fix for redux testing

### DIFF
--- a/src/containers/LeftPanel/TestCase/ReduxTestCase.jsx
+++ b/src/containers/LeftPanel/TestCase/ReduxTestCase.jsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import styles from '../TestCase/TestCase.module.scss';
 import { ReduxTestCaseContext } from '../../../context/reduxTestCaseReducer';
-import { updateReduxTestStatement } from '../../../context/reduxTestCaseActions';
+import { updateReduxTestStatement, updateStatementsOrder } from '../../../context/reduxTestCaseActions';
 import ReduxTestMenu from '../TestMenu/ReduxTestMenu';
 import ReduxTestStatements from './ReduxTestStatements';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
@@ -10,9 +10,32 @@ const ReduxTestCase = () => {
   const [{ reduxTestStatement, reduxStatements }, dispatchToReduxTestCase] = useContext(
     ReduxTestCaseContext
   );
+  // const draggableStatements = reduxStatements.slice(0,);
 
   const handleUpdateReduxTestStatement = e => {
     dispatchToReduxTestCase(updateReduxTestStatement(e.target.value));
+  };
+
+  const reorder = (list, startIndex, endIndex) => {
+    const result = Array.from(list);
+    const [removed] = result.splice(startIndex, 1);
+    result.splice(endIndex, 0, removed);
+    return result;
+  };
+
+  const onDragEnd = result => {
+    if (!result.destination) {
+      return;
+    }
+    if (result.destination.index === result.source.index) {
+      return;
+    }
+    const reorderedStatements = reorder(
+      reduxStatements,
+      result.source.index,
+      result.destination.index
+    );
+    dispatchToReduxTestCase(updateStatementsOrder(reorderedStatements));
   };
 
   return (
@@ -33,7 +56,7 @@ const ReduxTestCase = () => {
         </section>
       </div>
 
-      <DragDropContext>
+      <DragDropContext onDragEnd={onDragEnd}>
         <Droppable droppableId='droppable'>
           {provided => (
             <div ref={provided.innerRef} {...provided.droppableProps}>

--- a/src/context/reduxTestCaseActions.js
+++ b/src/context/reduxTestCaseActions.js
@@ -1,199 +1,179 @@
 export const actionTypes = {
-  TOGGLE_REDUX: 'TOGGLE_REDUX',
-
-  UPDATE_REDUX_TEST_STATEMENT: 'UPDATE_REDUX_TEST_STATEMENT',
-
-  ADD_MIDDLEWARE: 'ADD_MIDDLEWARE',
-  DELETE_MIDDLEWARE: 'DELETE_MIDDLEWARE',
-  UPDATE_MIDDLEWARE: 'UPDATE_MIDDLEWARE',
-
-  ADD_ACTIONCREATOR: 'ADD_ACTIONCREATOR',
-  DELETE_ACTIONCREATOR: 'DELETE_ACTIONCREATOR',
-  UPDATE_ACTIONCREATOR: 'UPDATE_ACTIONCREATORS',
-
-  ADD_ASYNC: 'ADD_ASYNC',
-  DELETE_ASYNC: 'DELETE_ASYNC',
-  UPDATE_ASYNC: 'UPDATE_ASYNC',
-
-  ADD_REDUCER: 'ADD_REDUCER',
-  DELETE_REDUCER: 'DELETE_REDUCER',
-  UPDATE_REDUCER: 'UPDATE_REDUCER',
-
-  UPDATE_MIDDLEWARES_FILEPATH: 'UPDATE_MIDDLEWARES_FILEPATH',
-  UPDATE_ACTIONS_FILEPATH: 'UPDATE_ACTIONS_FILEPATH',
-  UPDATE_TYPES_FILEPATH: 'UPDATE_TYPES_FILEPATH',
-  UPDATE_REDUCERS_FILEPATH: 'UPDATE_REDUCERS_FILEPATH',
-
-  CREATE_NEW_REDUX_TEST: 'CREATE_NEW_REDUX_TEST',
-};
-
-export const toggleRedux = () => ({
-  type: actionTypes.TOGGLE_REDUX,
-});
-
-export const updateReduxTestStatement = reduxTestStatement => ({
-  type: actionTypes.UPDATE_REDUX_TEST_STATEMENT,
-  reduxTestStatement,
-});
-
-export const addMiddleware = () => ({
-  type: actionTypes.ADD_MIDDLEWARE,
-});
-
-export const deleteMiddleware = id => ({
-  type: actionTypes.DELETE_MIDDLEWARE,
-  id,
-});
-
-export const updateMiddleware = ({
-  id,
-  eventType,
-  queryType,
-  eventValue,
-  queryVariant,
-  querySelector,
-  queryValue,
-  queryFunction,
-  suggestions,
-}) => ({
-  type: actionTypes.UPDATE_MIDDLEWARE,
-  id,
-  eventType,
-  queryType,
-  eventValue,
-  queryVariant,
-  querySelector,
-  queryValue,
-  queryFunction,
-  suggestions,
-});
-
-export const addActionCreator = () => ({
-  type: actionTypes.ADD_ACTIONCREATOR,
-});
-
-export const deleteActionCreator = id => ({
-  type: actionTypes.DELETE_ACTIONCREATOR,
-  id,
-});
-
-export const updateActionCreator = ({
-  id,
-  actionsFileName,
-  filePath,
-  typesFileName,
-  typesFilePath,
-  actionCreatorFunc,
-  actionType,
-  payloadKey,
-  payloadType,
-}) => ({
-  type: actionTypes.UPDATE_ACTIONCREATOR,
-  id,
-  actionsFileName,
-  filePath,
-  typesFileName,
-  typesFilePath,
-  actionCreatorFunc,
-  actionType,
-  payloadKey,
-  payloadType,
-});
-
-export const addAsync = () => ({
-  type: actionTypes.ADD_ASYNC,
-});
-
-export const deleteAsync = id => ({
-  type: actionTypes.DELETE_ASYNC,
-  id,
-});
-
-export const updateAsync = ({
-  id,
-  actionsFileName,
-  filePath,
-  typesFileName,
-  typesFilePath,
-  asyncFunction,
-  method,
-  route,
-  requestBody,
-  store,
-  matcher,
-  expectedResponse,
-}) => ({
-  type: actionTypes.UPDATE_ASYNC,
-  id,
-  actionsFileName,
-  filePath,
-  typesFileName,
-  typesFilePath,
-  asyncFunction,
-  method,
-  route,
-  requestBody,
-  store,
-  matcher,
-  expectedResponse,
-});
-
-export const addReducer = () => ({
-  type: actionTypes.ADD_REDUCER,
-});
-
-export const deleteReducer = id => ({
-  type: actionTypes.DELETE_REDUCER,
-  id,
-});
-
-export const updateReducer = ({
-  id,
-  reducerAction,
-  initialState,
-  reducerName,
-  typesFileName,
-  typesFilePath,
-  reducersFileName,
-  reducersFilePath,
-  expectedState,
-}) => ({
-  type: actionTypes.UPDATE_REDUCER,
-  id,
-  reducerAction,
-  initialState,
-  reducerName,
-  typesFileName,
-  typesFilePath,
-  reducersFileName,
-  reducersFilePath,
-  expectedState,
-});
-
-export const updateActionsFilePath = (actionsFileName, filePath) => ({
-  type: actionTypes.UPDATE_ACTIONS_FILEPATH,
-  actionsFileName,
-  filePath,
-});
-
-export const updateTypesFilePath = (typesFileName, typesFilePath) => ({
-  type: actionTypes.UPDATE_TYPES_FILEPATH,
-  typesFileName,
-  typesFilePath,
-});
-
-export const updateReducersFilePath = (reducersFileName, reducersFilePath) => ({
-  type: actionTypes.UPDATE_REDUCERS_FILEPATH,
-  reducersFileName,
-  reducersFilePath,
-});
-
-export const updateMiddlewaresFilePath = (middlewaresFileName, middlewaresFilePath) => ({
-  type: actionTypes.UPDATE_MIDDLEWARES_FILEPATH,
-  middlewaresFileName,
-  middlewaresFilePath,
-});
-
-export const createNewReduxTest = () => ({
-  type: actionTypes.CREATE_NEW_REDUX_TEST,
-});
+    TOGGLE_REDUX: 'TOGGLE_REDUX',
+    UPDATE_REDUX_TEST_STATEMENT: 'UPDATE_REDUX_TEST_STATEMENT',
+    ADD_MIDDLEWARE: 'ADD_MIDDLEWARE',
+    DELETE_MIDDLEWARE: 'DELETE_MIDDLEWARE',
+    UPDATE_MIDDLEWARE: 'UPDATE_MIDDLEWARE',
+    ADD_ACTIONCREATOR: 'ADD_ACTIONCREATOR',
+    DELETE_ACTIONCREATOR: 'DELETE_ACTIONCREATOR',
+    UPDATE_ACTIONCREATOR: 'UPDATE_ACTIONCREATORS',
+    ADD_ASYNC: 'ADD_ASYNC',
+    DELETE_ASYNC: 'DELETE_ASYNC',
+    UPDATE_ASYNC: 'UPDATE_ASYNC',
+    ADD_REDUCER: 'ADD_REDUCER',
+    DELETE_REDUCER: 'DELETE_REDUCER',
+    UPDATE_REDUCER: 'UPDATE_REDUCER',
+    UPDATE_MIDDLEWARES_FILEPATH: 'UPDATE_MIDDLEWARES_FILEPATH',
+    UPDATE_ACTIONS_FILEPATH: 'UPDATE_ACTIONS_FILEPATH',
+    UPDATE_TYPES_FILEPATH: 'UPDATE_TYPES_FILEPATH',
+    UPDATE_REDUCERS_FILEPATH: 'UPDATE_REDUCERS_FILEPATH',
+    UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
+    CREATE_NEW_REDUX_TEST: 'CREATE_NEW_REDUX_TEST',
+  };
+  export const toggleRedux = () => ({
+    type: actionTypes.TOGGLE_REDUX,
+  });
+  export const updateReduxTestStatement = reduxTestStatement => ({
+    type: actionTypes.UPDATE_REDUX_TEST_STATEMENT,
+    reduxTestStatement,
+  });
+  export const addMiddleware = () => ({
+    type: actionTypes.ADD_MIDDLEWARE,
+  });
+  export const deleteMiddleware = id => ({
+    type: actionTypes.DELETE_MIDDLEWARE,
+    id,
+  });
+  export const updateMiddleware = ({
+    id,
+    eventType,
+    queryType,
+    eventValue,
+    queryVariant,
+    querySelector,
+    queryValue,
+    queryFunction,
+    suggestions,
+  }) => ({
+    type: actionTypes.UPDATE_MIDDLEWARE,
+    id,
+    eventType,
+    queryType,
+    eventValue,
+    queryVariant,
+    querySelector,
+    queryValue,
+    queryFunction,
+    suggestions,
+  });
+  export const addActionCreator = () => ({
+    type: actionTypes.ADD_ACTIONCREATOR,
+  });
+  export const deleteActionCreator = id => ({
+    type: actionTypes.DELETE_ACTIONCREATOR,
+    id,
+  });
+  export const updateActionCreator = ({
+    id,
+    actionsFileName,
+    filePath,
+    typesFileName,
+    typesFilePath,
+    actionCreatorFunc,
+    actionType,
+    payloadKey,
+    payloadType,
+  }) => ({
+    type: actionTypes.UPDATE_ACTIONCREATOR,
+    id,
+    actionsFileName,
+    filePath,
+    typesFileName,
+    typesFilePath,
+    actionCreatorFunc,
+    actionType,
+    payloadKey,
+    payloadType,
+  });
+  export const addAsync = () => ({
+    type: actionTypes.ADD_ASYNC,
+  });
+  export const deleteAsync = id => ({
+    type: actionTypes.DELETE_ASYNC,
+    id,
+  });
+  export const updateAsync = ({
+    id,
+    actionsFileName,
+    filePath,
+    typesFileName,
+    typesFilePath,
+    asyncFunction,
+    method,
+    route,
+    requestBody,
+    store,
+    matcher,
+    expectedResponse,
+  }) => ({
+    type: actionTypes.UPDATE_ASYNC,
+    id,
+    actionsFileName,
+    filePath,
+    typesFileName,
+    typesFilePath,
+    asyncFunction,
+    method,
+    route,
+    requestBody,
+    store,
+    matcher,
+    expectedResponse,
+  });
+  export const addReducer = () => ({
+    type: actionTypes.ADD_REDUCER,
+  });
+  export const deleteReducer = id => ({
+    type: actionTypes.DELETE_REDUCER,
+    id,
+  });
+  export const updateReducer = ({
+    id,
+    reducerAction,
+    initialState,
+    reducerName,
+    typesFileName,
+    typesFilePath,
+    reducersFileName,
+    reducersFilePath,
+    expectedState,
+  }) => ({
+    type: actionTypes.UPDATE_REDUCER,
+    id,
+    reducerAction,
+    initialState,
+    reducerName,
+    typesFileName,
+    typesFilePath,
+    reducersFileName,
+    reducersFilePath,
+    expectedState,
+  });
+  export const updateActionsFilePath = (actionsFileName, filePath) => ({
+    type: actionTypes.UPDATE_ACTIONS_FILEPATH,
+    actionsFileName,
+    filePath,
+  });
+  export const updateTypesFilePath = (typesFileName, typesFilePath) => ({
+    type: actionTypes.UPDATE_TYPES_FILEPATH,
+    typesFileName,
+    typesFilePath,
+  });
+  export const updateReducersFilePath = (reducersFileName, reducersFilePath) => ({
+    type: actionTypes.UPDATE_REDUCERS_FILEPATH,
+    reducersFileName,
+    reducersFilePath,
+  });
+  export const updateMiddlewaresFilePath = (middlewaresFileName, middlewaresFilePath) => ({
+    type: actionTypes.UPDATE_MIDDLEWARES_FILEPATH,
+    middlewaresFileName,
+    middlewaresFilePath,
+  });
+  export const createNewReduxTest = () => ({
+    type: actionTypes.CREATE_NEW_REDUX_TEST,
+  });
+  export const updateStatementsOrder = draggableStatements => {
+    return {
+    type: actionTypes.UPDATE_STATEMENTS_ORDER,
+    draggableStatements,
+  }};

--- a/src/context/reduxTestCaseReducer.js
+++ b/src/context/reduxTestCaseReducer.js
@@ -1,20 +1,15 @@
 import { createContext } from 'react';
 import { actionTypes } from './reduxTestCaseActions';
-
 export const ReduxTestCaseContext = createContext(
   null
 ); /* here we create context for the redux test case. Dont provide it a default value (only used when you dont hve a provider for it), use null instead */
-
 /* initial state for testCase */
-
 export const reduxTestCaseState = {
   reduxTestStatement: '' /* the test description */,
   reduxStatements: [] /* both of the cards on the page at open. Each card gets an id */,
   hasRedux: 0,
 };
-
 let statementId = 0;
-
 const createMiddleware = () => ({
   id: statementId++,
   type: 'middleware',
@@ -27,7 +22,6 @@ const createMiddleware = () => ({
   queryValue: '',
   queryFunction: '',
 });
-
 const createActionCreator = () => ({
   id: statementId++,
   actionsFileName: '',
@@ -40,7 +34,6 @@ const createActionCreator = () => ({
   payloadKey: null,
   payloadType: null,
 });
-
 const createAsync = () => ({
   id: statementId++,
   type: 'async',
@@ -56,7 +49,6 @@ const createAsync = () => ({
   matcher: '',
   expectedResponse: '',
 });
-
 const createReducer = () => ({
   id: statementId++,
   type: 'reducer',
@@ -69,10 +61,8 @@ const createReducer = () => ({
   reducerName: '',
   expectedState: '',
 });
-
 export const reduxTestCaseReducer = (state, action) => {
   let reduxStatements = [...state.reduxStatements];
-
   switch (action.type) {
     case actionTypes.TOGGLE_REDUX:
       return {
@@ -119,21 +109,18 @@ export const reduxTestCaseReducer = (state, action) => {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.ADD_ACTIONCREATOR:
       reduxStatements.push(createActionCreator());
       return {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.DELETE_ACTIONCREATOR:
       reduxStatements = reduxStatements.filter(statement => statement.id !== action.id);
       return {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.UPDATE_ACTIONCREATOR:
       reduxStatements = reduxStatements.map(statement => {
         if (statement.id === action.id) {
@@ -152,7 +139,6 @@ export const reduxTestCaseReducer = (state, action) => {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.ADD_ASYNC:
       reduxStatements.push(createAsync());
       return {
@@ -185,7 +171,6 @@ export const reduxTestCaseReducer = (state, action) => {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.ADD_REDUCER:
       reduxStatements.push(createReducer());
       return {
@@ -216,7 +201,6 @@ export const reduxTestCaseReducer = (state, action) => {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.UPDATE_ACTIONS_FILEPATH:
       reduxStatements = reduxStatements.map(statement => {
         if (statement.type === 'async' || statement.type === 'action-creator') {
@@ -229,7 +213,6 @@ export const reduxTestCaseReducer = (state, action) => {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.UPDATE_TYPES_FILEPATH:
       reduxStatements = reduxStatements.map(statement => {
         if (
@@ -246,7 +229,6 @@ export const reduxTestCaseReducer = (state, action) => {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.UPDATE_REDUCERS_FILEPATH:
       reduxStatements = reduxStatements.map(statement => {
         if (statement.type === 'reducer') {
@@ -259,7 +241,6 @@ export const reduxTestCaseReducer = (state, action) => {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.UPDATE_MIDDLEWARES_FILEPATH:
       reduxStatements = reduxStatements.map(statement => {
         if (statement.type === 'middleware') {
@@ -272,13 +253,18 @@ export const reduxTestCaseReducer = (state, action) => {
         ...state,
         reduxStatements,
       };
-
     case actionTypes.CREATE_NEW_REDUX_TEST /* renders the new test card */:
       return {
         reduxTestStatement: '',
         reduxStatements: [],
         hasRedux: 0,
       };
+      case actionTypes.UPDATE_STATEMENTS_ORDER:
+        reduxStatements = [...action.draggableStatements];
+        return {
+          ...state,
+          reduxStatements,
+        };
     default:
       return state;
   }


### PR DESCRIPTION
# Fixes
(Issue#01) - user should be able to resort the redux test cards using drag and drop 