### PR TITLE
Creating context and new page for puppeteer testing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,11 @@ import styles from './App.module.scss';
 import { GlobalContext, globalState, globalReducer } from './context/globalReducer';
 import { ReactTestCaseContext, reactTestCaseState, reactTestCaseReducer } from './context/reactTestCaseReducer';
 import {
+  PuppeteerTestCaseContext,
+  puppeteerTestCaseState,
+  puppeteerTestCaseReducer,
+} from './context/puppeteerTestCaseReducer';
+import {
   EndpointTestCaseContext,
   endpointTestCaseState,
   endpointTestCaseReducer,
@@ -46,10 +51,15 @@ const App = () => {
     hooksTestCaseReducer,
     hooksTestCaseState
   );
+  const [puppeteerTestCase, dispatchToPuppeteerTestCase] = useReducer(
+    puppeteerTestCaseReducer,
+    puppeteerTestCaseState
+  );
   const [testFileModal, dispatchToTestFileModal] = useReducer(
     testFileModalReducer,
     testFileModalState
   );
+
 
   if (!global.isProjectLoaded) {
     return (
@@ -75,22 +85,22 @@ const App = () => {
        */
       <div id={global.isFileDirectoryOpen ? styles.appGridOpen : styles.appGridClose}>
         <GlobalContext.Provider value={[global, dispatchToGlobal]}>
-            <ReduxTestCaseContext.Provider value={[reduxTestCase, dispatchToReduxTestCase]}>
-          <ReactTestCaseContext.Provider value={[reactTestCase, dispatchToReactTestCase]}>
-              <EndpointTestCaseContext.Provider
-                value={[endpointTestCase, dispatchToEndpointTestCase]}
-              >
-                <HooksTestCaseContext.Provider value={[hooksTestCase, dispatchToHooksTestCase]}>
-                  <TestFileModalContext.Provider value={[testFileModal, dispatchToTestFileModal]}>
-                    <MockDataContext.Provider value={[mockData, dispatchToMockData]}>
-                      <NavBar />
-                      <LeftPanel />
-                    </MockDataContext.Provider>
-                  </TestFileModalContext.Provider>
-                </HooksTestCaseContext.Provider>
-              </EndpointTestCaseContext.Provider>
-          </ReactTestCaseContext.Provider>
-            </ReduxTestCaseContext.Provider>
+          <ReduxTestCaseContext.Provider value={[reduxTestCase, dispatchToReduxTestCase]}>
+            <ReactTestCaseContext.Provider value={[reactTestCase, dispatchToReactTestCase]}>
+                <EndpointTestCaseContext.Provider value={[endpointTestCase, dispatchToEndpointTestCase]}>
+                  <HooksTestCaseContext.Provider value={[hooksTestCase, dispatchToHooksTestCase]}>
+                    <TestFileModalContext.Provider value={[testFileModal, dispatchToTestFileModal]}>
+                      <MockDataContext.Provider value={[mockData, dispatchToMockData]}>
+                        <PuppeteerTestCaseContext.Provider value={[puppeteerTestCase, dispatchToPuppeteerTestCase]}>
+                          <NavBar />
+                          <LeftPanel />
+                        </PuppeteerTestCaseContext.Provider>
+                      </MockDataContext.Provider>
+                    </TestFileModalContext.Provider>
+                  </HooksTestCaseContext.Provider>
+                </EndpointTestCaseContext.Provider>
+            </ReactTestCaseContext.Provider>
+          </ReduxTestCaseContext.Provider>
           <RightPanel />
         </GlobalContext.Provider>
       </div>

--- a/src/containers/LeftPanel/TestCase/PuppeteerTestCase.jsx
+++ b/src/containers/LeftPanel/TestCase/PuppeteerTestCase.jsx
@@ -1,0 +1,40 @@
+import React, { useContext } from 'react';
+import styles from '../TestCase/TestCase.module.scss';
+import { PuppeteerTestCaseContext } from '../../../context/puppeteerTestCaseReducer';
+import PuppeteerTestMenu from '../TestMenu/PuppeteerTestMenu';
+import PuppeteerTestStatements from './PuppeteerTestStatements';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+
+const PuppeteerTestCase = () => {
+  const [{ puppeteerTestStatement, puppeteerStatements }, dispatchToPuppeteerTestCase] = useContext(PuppeteerTestCaseContext);
+
+  return (
+    <div>
+      <div id='head'>
+        <PuppeteerTestMenu dispatchToPuppeteerTestCase={dispatchToPuppeteerTestCase}/>
+      </div>
+
+      <div id={styles.testMockSection}>
+        <section  id={styles.testCaseHeader}>
+          <label htmlFor='test-statement'>Test</label>
+        </section>
+      </div>
+
+      <DragDropContext>
+          <Droppable droppableId='droppable'>
+            {provided => (
+              <div ref={provided.innerRef} {...provided.droppableProps}>
+                <PuppeteerTestStatements
+                  puppeteerStatements={puppeteerStatements}
+                  dispatchToPuppeteerTestCase={dispatchToPuppeteerTestCase}
+                />
+                {provided.placeholder}
+              </div>                        
+            )}
+          </Droppable>
+      </DragDropContext>
+    </div>
+  )
+}
+
+export default PuppeteerTestCase;

--- a/src/containers/LeftPanel/TestCase/PuppeteerTestStatements.jsx
+++ b/src/containers/LeftPanel/TestCase/PuppeteerTestStatements.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+const PuppeteerTestStatements = function puppeteerTestStatements({ puppeteerStatements, dispatchToPuppeteerTestCase }) { 
+    return puppeteerStatements.map((statement, i) => {
+        switch (statement.type) {
+          case 'form':
+            return (
+              <h1>FORM TESTING</h1>
+            );
+        default:
+            return <></>;
+        }
+     });
+
+};
+
+export default PuppeteerTestStatements;

--- a/src/containers/LeftPanel/TestFile/TestFile.jsx
+++ b/src/containers/LeftPanel/TestFile/TestFile.jsx
@@ -22,6 +22,11 @@ import { toggleEndpoint } from '../../../context/endpointTestCaseActions';
 import { EndpointTestCaseContext } from '../../../context/endpointTestCaseReducer';
 import EndpointTestCase from '../TestCase/EndpointTestCase';
 
+/* puppeteerTestCase imports */
+import { togglePuppeteer } from '../../../context/puppeteerTestCaseActions';
+import { PuppeteerTestCaseContext } from '../../../context/puppeteerTestCaseReducer';
+import PuppeteerTestCase from '../TestCase/PuppeteerTestCase';
+
 import { toggleModal } from '../../../context/testFileModalActions';
 import { TestFileModalContext } from '../../../context/testFileModalReducer';
 
@@ -30,6 +35,7 @@ const TestFile = () => {
   const [{ hasReact }, dispatchToTestCase] = useContext(ReactTestCaseContext);
   const [{ hasHooks }, dispatchToHooksTestCase] = useContext(HooksTestCaseContext);
   const [{ hasEndpoint }, dispatchToEndpointTestCase] = useContext(EndpointTestCaseContext);
+  const [{ hasPuppeteer }, dispatchToPuppeteerTestCase] = useContext(PuppeteerTestCaseContext);
   const [{ isTestModalOpen }, dispatchToTestFileModal] = useContext(TestFileModalContext);
 
   const closeTestModal = () => {
@@ -53,6 +59,11 @@ const TestFile = () => {
 
   const handleToggleHooks = e => {
     dispatchToHooksTestCase(toggleHooks());
+    closeTestModal();
+  };
+  
+  const handleTogglePuppeteer = e => {
+    dispatchToPuppeteerTestCase(togglePuppeteer());
     closeTestModal();
   };
 
@@ -92,6 +103,9 @@ const TestFile = () => {
             <button id={styles.save} onClick={handleToggleEndpoint}>
               Endpoint
             </button>
+            <button id={styles.save} onClick={handleTogglePuppeteer}>
+              Puppeteer
+            </button>
           </span>
         </div>
       </ReactModal>
@@ -119,6 +133,13 @@ const TestFile = () => {
           <HooksTestCase />
         </section>
       )}
+
+      {hasPuppeteer > 0 && (
+        <section>
+          <PuppeteerTestCase />
+        </section>
+      )}
+
     </div>
   );
 };

--- a/src/containers/LeftPanel/TestMenu/PuppeteerTestMenu.jsx
+++ b/src/containers/LeftPanel/TestMenu/PuppeteerTestMenu.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import styles from '../TestMenu/TestMenu.module.scss';
+import PuppeteerTestModal from '../../NavBar/Modals/PuppeteerTestModal';
+import { addPuppeteerForm } from '../../../context/puppeteerTestCaseActions';
+
+const PuppeteerTestMenu = ({ dispatchToPuppeteerTestCase }) => {
+  const [isPuppeteerModalOpen, setIsPuppeteerModalOpen] = useState(false);
+
+  const openPuppeteerModal = () => {
+    console.log('inside openPuppeteerModal')
+    setIsPuppeteerModalOpen(true);
+  };
+
+  const closePuppeteerModal = () => {
+    setIsPuppeteerModalOpen(false);
+  };
+
+  const handleAddPuppeteerForm = e => {
+    console.log('in handleAddPuppeteerForm')
+    dispatchToPuppeteerTestCase(addPuppeteerForm());
+  };
+
+  return (
+    <div id='test'>
+      <div id={styles.testMenu}>
+        <div id={styles.left}>
+          <button onClick={openPuppeteerModal}>New Test +</button>
+          <PuppeteerTestModal
+            isPuppeteerModalOpen={isPuppeteerModalOpen}
+            closePuppeteerModal={closePuppeteerModal}
+            dispatchToPuppeteerTestCase={dispatchToPuppeteerTestCase}
+          />
+        </div>
+        <div id={styles.right}>
+          <button data-testid='puppeteerFormButton' onClick={handleAddPuppeteerForm}>
+            Form
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PuppeteerTestMenu;

--- a/src/containers/NavBar/Modals/EndpointTestModal.jsx
+++ b/src/containers/NavBar/Modals/EndpointTestModal.jsx
@@ -32,6 +32,7 @@ const EndpointTestModal = ({
       contentLabel='Save?'
       shouldCloseOnOverlayClick={true}
       shouldCloseOnEsc={true}
+      ariaHideApp={false}
       style={modalStyles}
     >
       <div id={styles.title}>

--- a/src/containers/NavBar/Modals/NewTestModal.jsx
+++ b/src/containers/NavBar/Modals/NewTestModal.jsx
@@ -36,6 +36,7 @@ const NewTestModal = ({ isModalOpen, closeModal, dispatchToMockData, dispatchToT
       contentLabel='Save?'
       shouldCloseOnOverlayClick={true}
       shouldCloseOnEsc={true}
+      ariaHideApp={false}
       style={modalStyles}
     >
       <div id={styles.title}>

--- a/src/containers/NavBar/Modals/PuppeteerTestModal.jsx
+++ b/src/containers/NavBar/Modals/PuppeteerTestModal.jsx
@@ -1,0 +1,59 @@
+import React, { useContext } from 'react';
+import ReactModal from 'react-modal';
+import { createNewPuppeteerTest } from '../../../context/puppeteerTestCaseActions';
+import styles from '../../NavBar/Modals/ExportFileModal.module.scss';
+import { toggleModal } from '../../../context/testFileModalActions';
+import { TestFileModalContext } from '../../../context/testFileModalReducer';
+
+const PuppeteerTestModal = ({
+    isPuppeteerModalOpen,
+    closePuppeteerModal,
+    dispatchToPuppeteerTestCase,
+  }) => {
+    const [{ isTestModalOpen }, dispatchToTestFileModal] = useContext(TestFileModalContext);
+
+    const handleNewPuppeteerTest = e => {
+      dispatchToPuppeteerTestCase(createNewPuppeteerTest());
+      closePuppeteerModal();
+      dispatchToTestFileModal(toggleModal());
+    };
+
+    const modalStyles = {
+      overlay: {
+        zIndex: 3,
+      },
+    };
+
+    return (
+      <ReactModal
+        className={styles.modal}
+        isOpen={isPuppeteerModalOpen}
+        onRequestClose={closePuppeteerModal}
+        contentLabel='Save?'
+        shouldCloseOnOverlayClick={true}
+        shouldCloseOnEsc={true}
+        ariaHideApp={false}
+        style={modalStyles}
+      >
+        <div id={styles.title}>
+          <p>New Test</p>
+        </div>
+        <div id={styles.body}>
+          <p id={styles.text}>
+            Do you want to start a new test? All unsaved changes <br />
+            will be lost.
+          </p>
+          <span id={styles.newTestButtons}>
+            <button id={styles.save} onClick={handleNewPuppeteerTest}>
+              Continue
+            </button>
+            <button id={styles.save} onClick={closePuppeteerModal}>
+              Cancel
+            </button>
+          </span>
+        </div>
+      </ReactModal>
+    );
+};
+
+export default PuppeteerTestModal;

--- a/src/containers/NavBar/Modals/ReduxTestModal.jsx
+++ b/src/containers/NavBar/Modals/ReduxTestModal.jsx
@@ -28,6 +28,7 @@ const ReduxTestModal = ({ isReduxModalOpen, closeReduxModal, dispatchToReduxTest
       contentLabel='Save?' /* whats this? */
       shouldCloseOnOverlayClick={true}
       shouldCloseOnEsc={true}
+      ariaHideApp={false}
       style={modalStyles}
     >
       <div id={styles.title}>

--- a/src/context/puppeteerTestCaseActions.js
+++ b/src/context/puppeteerTestCaseActions.js
@@ -1,0 +1,24 @@
+export const actionTypes = {
+  TOGGLE_PUPPETEER: 'TOGGLE_PUPPETEER',
+  CREATE_NEW_PUPPETEER_TEST: 'CREATE_NEW_PUPPETEER_TEST',
+  ADD_PUPPETEERFORM: 'ADD_PUPPETEERFORM',
+  DELETE_PUPPETEERFORM: 'DELETE_PUPPETEERFORM',
+};
+
+export const togglePuppeteer = () => ({
+  type: actionTypes.TOGGLE_PUPPETEER,
+});
+
+export const createNewPuppeteerTest = () => ({
+  type: actionTypes.CREATE_NEW_PUPPETEER_TEST,
+});
+
+export const addPuppeteerForm = () => ({
+  type: actionTypes.CREATE_NEW_TEST,
+});
+
+export const deletePuppeteerForm = id => ({
+  type: actionTypes.DELETE_PUPPETEERFOR,
+  id,
+});
+

--- a/src/context/puppeteerTestCaseReducer.js
+++ b/src/context/puppeteerTestCaseReducer.js
@@ -1,0 +1,52 @@
+import { createContext } from 'react';
+import { actionTypes } from './puppeteerTestCaseActions';
+
+export const PuppeteerTestCaseContext = createContext(null);
+
+export const puppeteerTestCaseState = {
+  puppeteerTestStatement: '',
+  puppeteerStatements: [],
+  hasPuppeteer: 0,
+};
+
+let statementId = 0;
+
+const createPuppeteerForm = () => ({
+  id: statementId++,
+  type: 'puppeteerForm',
+});
+
+export const puppeteerTestCaseReducer = (state, action) => {
+  Object.freeze(state);
+  let puppeteerStatements = [...state.puppeteerStatements];
+
+  switch (action.type) {
+    case actionTypes.TOGGLE_PUPPETEER:
+      return {
+        ...state,
+        hasPuppeteer: state.hasPuppeteer + 1,
+      };
+
+    case actionTypes.ADD_PUPPETEERFORM:
+      puppeteerStatements.push(createPuppeteerForm());
+      return {
+        ...state,
+        puppeteerStatements,
+      };
+    case actionTypes.DELETE_PUPPETEERFORM:
+      puppeteerStatements = puppeteerStatements.filter(statement => statement.id !== action.id);
+      return {
+        ...state,
+        puppeteerStatements,
+      };
+
+    case actionTypes.CREATE_NEW_PUPPETEER_TEST:
+      return {
+        puppeteerTestStatement: '',
+        puppeteerStatements: [],
+        hasPuppeteer: 0,
+      };
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
- creating new context for puppeteer testing
- adding an option for puppeteer to the main modal
- implementing an event handler for the puppeteer option button so users are navigated to the puppeteer page
- new puppeteer page should display two buttons
   - [New Test +] (done) 
   - [Form] (WIP, waiting for the requirements to be finalized)
- minor fix for modal warnings by passing ariaHideApp={false}

<img width="1399" alt="Screen Shot 2020-05-08 at 6 06 56 PM" src="https://user-images.githubusercontent.com/46455259/81460007-70456600-9157-11ea-834a-5d1067dca9f4.png">
<img width="1399" alt="Screen Shot 2020-05-08 at 6 07 20 PM" src="https://user-images.githubusercontent.com/46455259/81460009-72a7c000-9157-11ea-9a1e-f5bc8bc2f1f9.png">
