### PR TITLE
collapse right panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,7 +83,10 @@ const App = () => {
        *
        * We access the value that we gave to the Provider through useContext
        */
-      <div id={global.isFileDirectoryOpen ? styles.appGridOpen : styles.appGridClose}>
+      <div id={global.isFileDirectoryOpen ? 
+        (global.isRightPanelOpen? styles.fileDirectoryOpenRightPanelOpen : styles.fileDirectoryOpenRightPanelClosed) :
+        (global.isRightPanelOpen? styles.fileDirectoryClosedRightPanelOpen : styles.fileDirectoryClosedRightPanelClosed) 
+      }>
         <GlobalContext.Provider value={[global, dispatchToGlobal]}>
           <ReduxTestCaseContext.Provider value={[reduxTestCase, dispatchToReduxTestCase]}>
             <ReactTestCaseContext.Provider value={[reactTestCase, dispatchToReactTestCase]}>
@@ -101,7 +104,7 @@ const App = () => {
                 </EndpointTestCaseContext.Provider>
             </ReactTestCaseContext.Provider>
           </ReduxTestCaseContext.Provider>
-          <RightPanel />
+          {global.isRightPanelOpen ?  <RightPanel /> : ''}
         </GlobalContext.Provider>
       </div>
     );

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -3,7 +3,17 @@
 @import 'assets/stylesheets/fonts';
 @import 'assets/stylesheets/colors';
 
-#appGridOpen {
+//file directory is open but right panel is closed
+#fileDirectoryOpenRightPanelClosed {
+  display: grid;
+  grid-template-columns: 280px auto;
+  grid-template-rows: 100vh;
+  grid-template-areas: 'navBar leftPanel';
+  background-color: $light-gray3;
+}
+
+//both open 
+#fileDirectoryOpenRightPanelOpen {
   display: grid;
   grid-template-columns: 280px auto 40%;
   grid-template-rows: 100vh;
@@ -11,10 +21,22 @@
   background-color: $light-gray3;
 }
 
-#appGridClose {
+//file directory is closed but right panel is open
+#fileDirectoryClosedRightPanelOpen {
   display: grid;
   grid-template-columns: 48px auto 50%;
   grid-template-rows: 100vh;
   grid-template-areas: 'navBar leftPanel rightPanel';
   background-color: $light-gray3;
 }
+
+//both closed
+#fileDirectoryClosedRightPanelClosed {
+  display: grid;
+  grid-template-columns: 48px auto;
+  grid-template-rows: 100vh;
+  grid-template-areas: 'navBar leftPanel';
+  background-color: $light-gray3;
+}
+
+

--- a/src/containers/RightPanel/RightPanel.jsx
+++ b/src/containers/RightPanel/RightPanel.jsx
@@ -3,12 +3,25 @@ import styles from './RightPanel.module.scss';
 import EditorView from './EditorView/EditorView';
 import BrowserView from './BrowserView/BrowserView';
 import { GlobalContext } from '../../context/globalReducer';
+import { closeRightPanel } from '../../context/globalActions';
+const closeIcon = require('../../assets/images/close.png');
 
 const RightPanel = () => {
-  const [{ rightPanelDisplay, url }, _] = useContext(GlobalContext);
-
+  const [{ rightPanelDisplay, url }, dispatchToGlobal] = useContext(GlobalContext);
+  
+  const handleCloseRightPanelView = () => {
+    dispatchToGlobal(closeRightPanel());
+  };
+  
   return (
     <div id={styles.rightPanel}>
+      <img
+        src={closeIcon}
+        id={styles.close}
+        alt='close'
+        onClick={handleCloseRightPanelView}
+      />
+
       {url && rightPanelDisplay === 'browserView' ? <BrowserView /> : <></>}
       {!url || rightPanelDisplay === 'codeEditorView' ? <EditorView /> : <></>}
     </div>

--- a/src/containers/RightPanel/RightPanel.module.scss
+++ b/src/containers/RightPanel/RightPanel.module.scss
@@ -1,5 +1,11 @@
 #rightPanel {
+  display: flex;
+  flex-direction: column;
   grid-area: rightPanel;
   grid-column-start: 3;
   padding: 8px 7px 5px 5px;
+}
+#close {
+  align-self: flex-end;
+  margin-right: .5rem;
 }

--- a/src/containers/RightPanel/RightPanel.module.scss
+++ b/src/containers/RightPanel/RightPanel.module.scss
@@ -8,4 +8,5 @@
 #close {
   align-self: flex-end;
   margin-right: .5rem;
+  cursor: pointer;
 }

--- a/src/context/globalActions.js
+++ b/src/context/globalActions.js
@@ -4,6 +4,7 @@ export const actionTypes = {
   CREATE_FILE_TREE: 'CREATE_FILE_TREE',
   SET_COMPONENT_NAME: 'SET_COMPONENT_NAME',
   TOGGLE_FILE_DIRECTORY: 'TOGGLE_FILE_DIRECTORY',
+  CLOSE_RIGHT_PANEL: 'CLOSE_RIGHT_PANEL',
   TOGGLE_RIGHT_PANEL: 'TOGGLE_RIGHT_PANEL',
   DISPLAY_FILE_CODE: 'DISPLAY_FILE_CODE',
   TOGGLE_FOLDER_VIEW: 'TOGGLE_FOLDER_VIEW',
@@ -35,6 +36,10 @@ export const setComponentName = componentName => ({
 
 export const toggleFileDirectory = () => ({
   type: actionTypes.TOGGLE_FILE_DIRECTORY,
+});
+
+export const closeRightPanel = () => ({
+  type: actionTypes.CLOSE_RIGHT_PANEL,
 });
 
 export const toggleRightPanel = display => ({

--- a/src/context/globalReducer.js
+++ b/src/context/globalReducer.js
@@ -9,6 +9,7 @@ export const globalState = {
   fileTree: null,
   componentName: '',
   isFileDirectoryOpen: true,
+  isRightPanelOpen: true,
   rightPanelDisplay: 'browserView',
   displayedFileCode: '',
   isFolderOpen: {},
@@ -50,11 +51,17 @@ export const globalReducer = (state, action) => {
         ...state,
         isFileDirectoryOpen,
       };
+    case actionTypes.CLOSE_RIGHT_PANEL:
+      return {
+        ...state,
+        isRightPanelOpen: false,
+      };
     case actionTypes.TOGGLE_RIGHT_PANEL:
       const rightPanelDisplay = action.display;
       return {
         ...state,
         rightPanelDisplay,
+        isRightPanelOpen: true,
       };
     case actionTypes.DISPLAY_FILE_CODE:
       const displayedFileCode = action.displayedFileCode;


### PR DESCRIPTION
- user can collapse the right panel when [X] image is clicked
- user can expand the right panel when the code review icon or browser view icon (on the navbar) is clicked

*--------------------note--------------------*
the size of the electron app is set in electron.js (midWidth: 1400)
collapsing the right panel doesn't affect the width of the app. 