### PR TITLE
Puppeteer Paint Timing 

### DIFF
--- a/src/containers/LeftPanel/PaintTiming/PaintTiming.jsx
+++ b/src/containers/LeftPanel/PaintTiming/PaintTiming.jsx
@@ -1,22 +1,60 @@
 import React, { useContext } from 'react';
-import styles from '../Endpoint/Endpoint.module.scss';
+import styles from './PaintTiming.module.scss';
 import {
   deletePuppeteerTest,
+  addBrowserOption,
+  deleteBrowserOption,
+  updatePaintTiming,
+  updateBrowserOption,
 } from '../../../context/puppeteerTestCaseActions';
 import { Draggable } from 'react-beautiful-dnd';
+
 const closeIcon = require('../../../assets/images/close.png');
 const dragIcon = require('../../../assets/images/drag-vertical.png');
+const plusIcon = require('../../../assets/images/plus.png');
+const minusIcon = require('../../../assets/images/minus-box-outline.png');
 
 const PaintTiming = ({ paintTiming, index, dispatchToPuppeteerTestCase }) => {
-  // const handleChangeEndpointFields = (e, field) => {
-  //   let updatedEndpoint = { ...endpoint };
-  //   updatedEndpoint[field] = e.target.value;
-  //   dispatchToEndpointTestCase(updateEndpoint(updatedEndpoint));
-  // };
+  const handleChangePaintTimingFields = (e, field) => {
+    dispatchToPuppeteerTestCase(updatePaintTiming(paintTiming.id, field, e.target.value));
+  };
+
+  const handleChangeBrowserOptionFields = (e, field, optionId) => {
+    dispatchToPuppeteerTestCase(updateBrowserOption(paintTiming.id, field, e.target.value, optionId));
+  };
 
   const handleClickDeletePaintTiming = e => {
     dispatchToPuppeteerTestCase(deletePuppeteerTest(paintTiming.id));
   };
+
+  const handleAddBrowserOptions = e => {
+    dispatchToPuppeteerTestCase(addBrowserOption(paintTiming.id));
+  };
+
+  const handleClickDeleteBrowserOption = e => {
+    dispatchToPuppeteerTestCase(deleteBrowserOption(paintTiming.id, Number(e.target.id)));
+  }
+
+
+  const browserOptionsJSX = paintTiming.browserOptions.map(option => {
+    return (
+      <div id={styles.browserOptionsFlexBox} key={option.id}>
+        <input 
+          type='text' 
+          key={`key${option.id}`} 
+          id={`key${option.id}`} 
+          onChange={e => handleChangeBrowserOptionFields(e, 'optionKey', option.id)} 
+        />
+        <input 
+          type='text' 
+          key={`value${option.id}`} 
+          id={`value${option.id}`} 
+          onChange={e => handleChangeBrowserOptionFields(e, 'optionValue', option.id)}  
+        />
+        <img src={minusIcon} alt='delete' id={option.id} onClick={handleClickDeleteBrowserOption} />
+      </div>
+    );
+  });
 
   return (
     <Draggable draggableId={paintTiming.id.toString()} index={index}>
@@ -33,17 +71,113 @@ const PaintTiming = ({ paintTiming, index, dispatchToPuppeteerTestCase }) => {
             <img src={dragIcon} alt='drag' />
             <h3>Paint Timing</h3>
           </div>
-
+          
           <div id={styles.groupFlexbox}>
-            <label htmlFor='first-paint'>
-              Input
+            <label htmlFor='test'>
+              Test
             </label>
             <div id={styles.inputFlexBox}>
               <input
                 type='text'
-                name='first-paint'
-                placeholder='100'
-                // onChange={e => handleChangeEndpointFields(e, 'route')} 
+                name='test'
+                onChange={e => handleChangePaintTimingFields(e, 'test')} 
+              />
+            </div>
+          </div>
+          
+          <div id={styles.groupFlexbox}>
+            <label htmlFor='url'>
+              URL
+            </label>
+            <div id={styles.inputFlexBox}>
+              <input
+                type='text'
+                name='url'
+                placeholder='http://localhost:8080/'
+                onChange={e => handleChangePaintTimingFields(e, 'url')} 
+              />
+            </div>
+            <div id={styles.renderCheckbox}>
+              <input
+                type='checkbox'
+                id='render-checkbox'
+                disabled={paintTiming.browserOptions.length}
+                checked={paintTiming.hasBrowserOption}
+                onChange={handleAddBrowserOptions}
+              />
+              <label htmlFor='render-checkbox'>Add Browser Options? </label>
+            </div>
+          </div>
+          {paintTiming.browserOptions.length !== 0 && (
+            <div>
+              <div id={styles.browserOptions}>
+                <label htmlFor='option-key'>
+                  Option key
+                </label>
+                <label htmlFor='option-value'>
+                  Option value
+                </label>
+              </div>
+              <hr />
+              {browserOptionsJSX}
+              <div id={styles.options}>
+                <button onClick={handleAddBrowserOptions}>
+                  <img src={plusIcon} alt='add' />
+                  Add Prop
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* -------------------------------------- */}
+          <div id={styles.groupFlexbox}>
+            <label htmlFor='first-paint'>
+              First Paint
+            </label>
+            <div id={styles.inputFlexBox}>
+              <input
+                type='text'
+                name='first-paint-it'
+                onChange={e => handleChangePaintTimingFields(e, 'firstPaintIt')} 
+              />
+              <input
+                type='text'
+                name='first-paint-benchmark'
+                onChange={e => handleChangePaintTimingFields(e, 'firstPaintTime')} 
+              />
+            </div>
+          </div>
+          <div id={styles.groupFlexbox}>
+            <label htmlFor='first-contentful-paint'>
+              First Contentful Paint
+            </label>
+            <div id={styles.inputFlexBox}>
+              <input
+                type='text'
+                name='first-contentful-paint-it'
+                onChange={e => handleChangePaintTimingFields(e, 'FCPIt')} 
+              />
+              <input
+                type='text'
+                name='first-contentful-paint-benchmark'
+                onChange={e => handleChangePaintTimingFields(e, 'FCPtTime')} 
+              />
+            </div>
+          </div>
+          <div id={styles.groupFlexbox}>
+            <label htmlFor='largest-contentful-paint'>
+              Largest Contentful Paint
+            </label>
+            <div id={styles.inputFlexBox}>
+              <input
+                type='text'
+                name='largest-contentful-paint-it'
+                onChange={e => handleChangePaintTimingFields(e, 'LCPPaint')} 
+              />
+              <input
+                type='text'
+                name='largest-contentful-paint-benchmark'
+                onChange={e => handleChangePaintTimingFields(e, 'LCPTime')} 
               />
             </div>
           </div>

--- a/src/containers/LeftPanel/PaintTiming/PaintTiming.jsx
+++ b/src/containers/LeftPanel/PaintTiming/PaintTiming.jsx
@@ -1,0 +1,56 @@
+import React, { useContext } from 'react';
+import styles from '../Endpoint/Endpoint.module.scss';
+import {
+  deletePuppeteerTest,
+} from '../../../context/puppeteerTestCaseActions';
+import { Draggable } from 'react-beautiful-dnd';
+const closeIcon = require('../../../assets/images/close.png');
+const dragIcon = require('../../../assets/images/drag-vertical.png');
+
+const PaintTiming = ({ paintTiming, index, dispatchToPuppeteerTestCase }) => {
+  // const handleChangeEndpointFields = (e, field) => {
+  //   let updatedEndpoint = { ...endpoint };
+  //   updatedEndpoint[field] = e.target.value;
+  //   dispatchToEndpointTestCase(updateEndpoint(updatedEndpoint));
+  // };
+
+  const handleClickDeletePaintTiming = e => {
+    dispatchToPuppeteerTestCase(deletePuppeteerTest(paintTiming.id));
+  };
+
+  return (
+    <Draggable draggableId={paintTiming.id.toString()} index={index}>
+      {provided => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          id={styles.modal}
+        >
+          <img src={closeIcon} id={styles.close} alt='close' onClick={handleClickDeletePaintTiming} />
+
+          <div id={styles.header}>
+            <img src={dragIcon} alt='drag' />
+            <h3>Paint Timing</h3>
+          </div>
+
+          <div id={styles.groupFlexbox}>
+            <label htmlFor='first-paint'>
+              Input
+            </label>
+            <div id={styles.inputFlexBox}>
+              <input
+                type='text'
+                name='first-paint'
+                placeholder='100'
+                // onChange={e => handleChangeEndpointFields(e, 'route')} 
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </Draggable>
+  );
+};
+
+export default PaintTiming;

--- a/src/containers/LeftPanel/PaintTiming/PaintTiming.jsx
+++ b/src/containers/LeftPanel/PaintTiming/PaintTiming.jsx
@@ -1,60 +1,24 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import styles from './PaintTiming.module.scss';
 import {
   deletePuppeteerTest,
-  addBrowserOption,
-  deleteBrowserOption,
   updatePaintTiming,
-  updateBrowserOption,
 } from '../../../context/puppeteerTestCaseActions';
+import ToolTip from '../ToolTip/ToolTip';
 import { Draggable } from 'react-beautiful-dnd';
-
+import PuppeteerBrowserSetting from '../PuppeteerBrowerSetting/PuppeteerBrowserSetting'
 const closeIcon = require('../../../assets/images/close.png');
 const dragIcon = require('../../../assets/images/drag-vertical.png');
-const plusIcon = require('../../../assets/images/plus.png');
-const minusIcon = require('../../../assets/images/minus-box-outline.png');
+const questionIcon = require('../../../assets/images/help-circle.png');
 
 const PaintTiming = ({ paintTiming, index, dispatchToPuppeteerTestCase }) => {
   const handleChangePaintTimingFields = (e, field) => {
     dispatchToPuppeteerTestCase(updatePaintTiming(paintTiming.id, field, e.target.value));
   };
-
-  const handleChangeBrowserOptionFields = (e, field, optionId) => {
-    dispatchToPuppeteerTestCase(updateBrowserOption(paintTiming.id, field, e.target.value, optionId));
-  };
-
   const handleClickDeletePaintTiming = e => {
     dispatchToPuppeteerTestCase(deletePuppeteerTest(paintTiming.id));
   };
 
-  const handleAddBrowserOptions = e => {
-    dispatchToPuppeteerTestCase(addBrowserOption(paintTiming.id));
-  };
-
-  const handleClickDeleteBrowserOption = e => {
-    dispatchToPuppeteerTestCase(deleteBrowserOption(paintTiming.id, Number(e.target.id)));
-  }
-
-
-  const browserOptionsJSX = paintTiming.browserOptions.map(option => {
-    return (
-      <div id={styles.browserOptionsFlexBox} key={option.id}>
-        <input 
-          type='text' 
-          key={`key${option.id}`} 
-          id={`key${option.id}`} 
-          onChange={e => handleChangeBrowserOptionFields(e, 'optionKey', option.id)} 
-        />
-        <input 
-          type='text' 
-          key={`value${option.id}`} 
-          id={`value${option.id}`} 
-          onChange={e => handleChangeBrowserOptionFields(e, 'optionValue', option.id)}  
-        />
-        <img src={minusIcon} alt='delete' id={option.id} onClick={handleClickDeleteBrowserOption} />
-      </div>
-    );
-  });
 
   return (
     <Draggable draggableId={paintTiming.id.toString()} index={index}>
@@ -72,64 +36,13 @@ const PaintTiming = ({ paintTiming, index, dispatchToPuppeteerTestCase }) => {
             <h3>Paint Timing</h3>
           </div>
           
-          <div id={styles.groupFlexbox}>
-            <label htmlFor='test'>
-              Test
-            </label>
-            <div id={styles.inputFlexBox}>
-              <input
-                type='text'
-                name='test'
-                onChange={e => handleChangePaintTimingFields(e, 'test')} 
-              />
-            </div>
-          </div>
-          
-          <div id={styles.groupFlexbox}>
-            <label htmlFor='url'>
-              URL
-            </label>
-            <div id={styles.inputFlexBox}>
-              <input
-                type='text'
-                name='url'
-                placeholder='http://localhost:8080/'
-                onChange={e => handleChangePaintTimingFields(e, 'url')} 
-              />
-            </div>
-            <div id={styles.renderCheckbox}>
-              <input
-                type='checkbox'
-                id='render-checkbox'
-                disabled={paintTiming.browserOptions.length}
-                checked={paintTiming.hasBrowserOption}
-                onChange={handleAddBrowserOptions}
-              />
-              <label htmlFor='render-checkbox'>Add Browser Options? </label>
-            </div>
-          </div>
-          {paintTiming.browserOptions.length !== 0 && (
-            <div>
-              <div id={styles.browserOptions}>
-                <label htmlFor='option-key'>
-                  Option key
-                </label>
-                <label htmlFor='option-value'>
-                  Option value
-                </label>
-              </div>
-              <hr />
-              {browserOptionsJSX}
-              <div id={styles.options}>
-                <button onClick={handleAddBrowserOptions}>
-                  <img src={plusIcon} alt='add' />
-                  Add Prop
-                </button>
-              </div>
-            </div>
-          )}
+          <PuppeteerBrowserSetting 
+            puppeteer={paintTiming} 
+            dispatchToPuppeteerTestCase={dispatchToPuppeteerTestCase}
+            updatePuppeteer={updatePaintTiming}
+            handleChangePuppeteerFields={handleChangePaintTimingFields}
+          />
 
-          {/* -------------------------------------- */}
           <div id={styles.groupFlexbox}>
             <label htmlFor='first-paint'>
               First Paint
@@ -138,13 +51,23 @@ const PaintTiming = ({ paintTiming, index, dispatchToPuppeteerTestCase }) => {
               <input
                 type='text'
                 name='first-paint-it'
+                placeholder='should have its first paint in less than 100 ms'
                 onChange={e => handleChangePaintTimingFields(e, 'firstPaintIt')} 
               />
-              <input
-                type='text'
-                name='first-paint-benchmark'
-                onChange={e => handleChangePaintTimingFields(e, 'firstPaintTime')} 
-              />
+              <div id={styles.time}>
+                <input
+                  type='text'
+                  name='first-paint-benchmark'
+                  placeholder={100}
+                  onChange={e => handleChangePaintTimingFields(e, 'firstPaintTime')} 
+                />
+              </div>
+              <span id={styles.hastooltip} role='tooltip'>
+                <img src={questionIcon} alt='help' />
+                <span id={styles.tooltip}>
+                  <ToolTip toolTipType={'FPTarget'} />
+                </span>
+              </span>
             </div>
           </div>
           <div id={styles.groupFlexbox}>
@@ -155,13 +78,23 @@ const PaintTiming = ({ paintTiming, index, dispatchToPuppeteerTestCase }) => {
               <input
                 type='text'
                 name='first-contentful-paint-it'
+                placeholder='should have its first meaningful paint in less than 100 ms'
                 onChange={e => handleChangePaintTimingFields(e, 'FCPIt')} 
               />
-              <input
-                type='text'
-                name='first-contentful-paint-benchmark'
-                onChange={e => handleChangePaintTimingFields(e, 'FCPtTime')} 
-              />
+              <div id={styles.time}>
+                <input
+                  type='text'
+                  name='first-contentful-paint-benchmark'
+                  placeholder={100}
+                  onChange={e => handleChangePaintTimingFields(e, 'FCPtTime')} 
+                />
+              </div>
+              <span id={styles.hastooltip} role='tooltip'>
+                <img src={questionIcon} alt='help' />
+                <span id={styles.tooltip}>
+                  <ToolTip toolTipType={'FCPTarget'} />
+                </span>
+              </span>
             </div>
           </div>
           <div id={styles.groupFlexbox}>
@@ -172,13 +105,23 @@ const PaintTiming = ({ paintTiming, index, dispatchToPuppeteerTestCase }) => {
               <input
                 type='text'
                 name='largest-contentful-paint-it'
-                onChange={e => handleChangePaintTimingFields(e, 'LCPPaint')} 
+                placeholder='should have its largest meaningful paint in less than 250 ms'
+                onChange={e => handleChangePaintTimingFields(e, 'LCPIt')} 
               />
-              <input
-                type='text'
-                name='largest-contentful-paint-benchmark'
-                onChange={e => handleChangePaintTimingFields(e, 'LCPTime')} 
-              />
+              <div id={styles.time}>
+                <input
+                  type='text'
+                  name='largest-contentful-paint-benchmark'
+                  placeholder={250}
+                  onChange={e => handleChangePaintTimingFields(e, 'LCPTime')} 
+                />
+              </div>
+              <span id={styles.hastooltip} role='tooltip'>
+                <img src={questionIcon} alt='help' />
+                <span id={styles.tooltip}>
+                  <ToolTip toolTipType={'LCPTarget'} />
+                </span>
+              </span>
             </div>
           </div>
         </div>

--- a/src/containers/LeftPanel/PaintTiming/PaintTiming.module.scss
+++ b/src/containers/LeftPanel/PaintTiming/PaintTiming.module.scss
@@ -30,6 +30,10 @@
   }
 }
 
+#testingFieldsGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr
+}
 #groupFlexbox {
   display: flex;
   align-items: center;
@@ -37,75 +41,55 @@
   justify-content: space-between;
 }
 
-#alignRight {
-  width: 43%;
-  margin-right: 7%;
-  input {
-    margin-top: 6px;
-    width: 100%;
-  }
-}
-
-#serverInput {
-  width: 43%;
-  margin-right: 7%;
-  input {
-    margin-top: 6px;
-    width: 100%;
-  }
-}
-
-#labelInput {
-  width: 100%;
-  margin-right: 7%;
-  input {
-    margin-top: 6px;
-    width: 100%;
-  }
-  position: relative;
-}
-
-#dropdownWrapper {
-  margin-right: 9%;
-  select {
-    font-family: $raleway;
-    width: 100%;
-    height: 25px;
-    margin: 0 3px 0 0;
-    background-color: white;
-    border: 1px solid $light-gray;
-    font-size: 12px;
-    letter-spacing: 0.5px;
-    color: $dark-gray;
-  }
-}
-
-#dropdownFlex {
-  display: flex;
-  align-items: center;
-  width: 340%;
-  margin-top: 6px;
-}
-
 #inputFlexBox {
   display: flex;
   align-items: center;
   width: 100%;
+  input {
+    width: inherit;
+  }
 }
 
-#hastooltip {
-  @include hastooltip($tooltip-transition-in-duration: 0.3s);
+#renderCheckbox {
+  margin-left: 2rem;
+  display: flex;
+  input {
+    align-self: center;
+  }
 }
 
-#tooltip {
-  min-width: 10em;
-  padding: 0.5em 0.75em;
+#browserOptionsFlexBox {
+  display: flex;
+  justify-content: center;
+  align-items: center;
 
-  box-shadow: 0 0.05em 0.15em rgba(black, 0.1);
-  @include tooltip;
+  input {
+    width: 240px;
+    margin: 0 4px 4px 0px;
+  }
+
+  img {
+    margin-bottom: 5px;
+  }
 }
 
-#matcher {
-  margin-top: 1em;
-  margin-right: 3em;
+#browserOptions {
+  font-size: 13px;
+  margin-bottom: 0;
+  padding: 6px 0;
+  display: flex;
+  width: 60%;
+  justify-content: space-between;
+}
+
+#options {
+  margin: 5px 0 15px;
+  button {
+    font-size: 12px;
+    padding-top: 5px;
+    border: none;
+    font-family: $raleway;
+    font-weight: bold;
+    text-align: left;
+  }
 }

--- a/src/containers/LeftPanel/PaintTiming/PaintTiming.module.scss
+++ b/src/containers/LeftPanel/PaintTiming/PaintTiming.module.scss
@@ -1,0 +1,111 @@
+@import '../../../assets/stylesheets/fonts.scss';
+@import '../../../assets/stylesheets/colors.scss';
+@import '../LeftPanel.module.scss';
+
+
+#modal {
+  @include box-styling;
+  font-family: $raleway;
+  letter-spacing: 0.5px;
+}
+
+#close {
+  float: right;
+}
+
+#header {
+  @include box-header-alignment;
+  justify-content: flex-start;
+  display: flex;
+  align-items: center;
+  img {
+    width: 20px;
+    height: 20px;
+    margin: 0;
+    padding: 0;
+  }
+  h3 {
+    margin: 0;
+    padding: 0;
+  }
+}
+
+#groupFlexbox {
+  display: flex;
+  align-items: center;
+  margin-bottom: 15px;
+  justify-content: space-between;
+}
+
+#alignRight {
+  width: 43%;
+  margin-right: 7%;
+  input {
+    margin-top: 6px;
+    width: 100%;
+  }
+}
+
+#serverInput {
+  width: 43%;
+  margin-right: 7%;
+  input {
+    margin-top: 6px;
+    width: 100%;
+  }
+}
+
+#labelInput {
+  width: 100%;
+  margin-right: 7%;
+  input {
+    margin-top: 6px;
+    width: 100%;
+  }
+  position: relative;
+}
+
+#dropdownWrapper {
+  margin-right: 9%;
+  select {
+    font-family: $raleway;
+    width: 100%;
+    height: 25px;
+    margin: 0 3px 0 0;
+    background-color: white;
+    border: 1px solid $light-gray;
+    font-size: 12px;
+    letter-spacing: 0.5px;
+    color: $dark-gray;
+  }
+}
+
+#dropdownFlex {
+  display: flex;
+  align-items: center;
+  width: 340%;
+  margin-top: 6px;
+}
+
+#inputFlexBox {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+#hastooltip {
+  @include hastooltip($tooltip-transition-in-duration: 0.3s);
+}
+
+#tooltip {
+  min-width: 10em;
+  padding: 0.5em 0.75em;
+
+  box-shadow: 0 0.05em 0.15em rgba(black, 0.1);
+  @include tooltip;
+}
+
+#matcher {
+  margin-top: 1em;
+  margin-right: 3em;
+}

--- a/src/containers/LeftPanel/PaintTiming/PaintTiming.module.scss
+++ b/src/containers/LeftPanel/PaintTiming/PaintTiming.module.scss
@@ -46,12 +46,19 @@
   align-items: center;
   width: 100%;
   input {
+    margin-right: 0.5rem;
     width: inherit;
   }
 }
 
+#time {
+  width: 30%;
+  input {
+    width: 100%;
+  }
+}
+
 #renderCheckbox {
-  margin-left: 2rem;
   display: flex;
   input {
     align-self: center;
@@ -62,12 +69,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
-
   input {
     width: 240px;
     margin: 0 4px 4px 0px;
   }
-
   img {
     margin-bottom: 5px;
   }
@@ -92,4 +97,24 @@
     font-weight: bold;
     text-align: left;
   }
+}
+
+#optionBox {
+  hr {
+    border: 1px solid $light-gray;
+    margin-top: 0;
+  }
+}
+
+#hastooltip {
+  margin-left: 0.2rem;
+  @include hastooltip($tooltip-transition-in-duration: 0.3s);
+}
+
+#tooltip {
+  min-width: 10em;
+  padding: 0.5em 0.75em;
+
+  box-shadow: 0 0.05em 0.15em rgba(black, 0.1);
+  @include tooltip;
 }

--- a/src/containers/LeftPanel/PuppeteerBrowerSetting/PuppeteerBrowserSetting.jsx
+++ b/src/containers/LeftPanel/PuppeteerBrowerSetting/PuppeteerBrowserSetting.jsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import styles from '../PaintTiming/PaintTiming.module.scss';
+import {
+  addBrowserOption,
+  deleteBrowserOption,
+  updateBrowserOption,
+} from '../../../context/puppeteerTestCaseActions';
+
+const plusIcon = require('../../../assets/images/plus.png');
+const minusIcon = require('../../../assets/images/minus-box-outline.png');
+
+const PuppeteerBrowserSetting = ({ puppeteer, dispatchToPuppeteerTestCase, handleChangePuppeteerFields }) => {
+  const handleChangeBrowserOptionFields = (e, field, optionId) => {
+    dispatchToPuppeteerTestCase(updateBrowserOption(puppeteer.id, field, e.target.value, optionId));
+  };
+
+  const handleAddBrowserOptions = () => {
+    dispatchToPuppeteerTestCase(addBrowserOption(puppeteer.id));
+  };
+
+  const handleClickDeleteBrowserOption = e => {
+    dispatchToPuppeteerTestCase(deleteBrowserOption(puppeteer.id, Number(e.target.id)));
+  }
+
+
+  const browserOptionsJSX = puppeteer.browserOptions.map(option => {
+    return (
+      <div id={styles.browserOptionsFlexBox} key={option.id}>
+        <input 
+          type='text' 
+          key={`key${option.id}`} 
+          id={`key${option.id}`} 
+          onChange={e => handleChangeBrowserOptionFields(e, 'optionKey', option.id)} 
+        />
+        <input 
+          type='text' 
+          key={`value${option.id}`} 
+          id={`value${option.id}`} 
+          onChange={e => handleChangeBrowserOptionFields(e, 'optionValue', option.id)}  
+        />
+        <img src={minusIcon} alt='delete' id={option.id} onClick={handleClickDeleteBrowserOption} />
+      </div>
+    );
+  });
+
+  return (     
+    <div>   
+      <div id={styles.groupFlexbox}>
+        <label htmlFor='test'>
+          Describe
+        </label>
+        <div id={styles.inputFlexBox}>
+          <input
+            type='text'
+            name='test'
+            placeholder='eg. Home page performance'
+            onChange={e => handleChangePuppeteerFields(e, 'describe')} 
+          />
+        </div>
+      </div>
+      
+      <div id={styles.groupFlexbox}>
+        <label htmlFor='url'>
+          URL &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+        </label>
+        <div id={styles.inputFlexBox}>
+          <input
+            type='text'
+            name='url'
+            placeholder='http://localhost:8080/'
+            onChange={e => handleChangePuppeteerFields(e, 'url')} 
+          />
+        </div>
+        <div id={styles.renderCheckbox}>
+          <input
+            type='checkbox'
+            id='render-checkbox'
+            disabled={puppeteer.browserOptions.length}
+            checked={puppeteer.hasBrowserOption}
+            onChange={handleAddBrowserOptions}
+          />
+          <label htmlFor='render-checkbox'>Add Browser Options? </label>
+        </div>
+      </div>
+
+      {puppeteer.browserOptions.length !== 0 && (
+        <div id={styles.optionBox}>
+          <div id={styles.browserOptions}>
+            <label htmlFor='option-key'>
+              Option key
+            </label>
+            <label htmlFor='option-value'>
+              Option value
+            </label>
+          </div>
+          <hr />
+          {browserOptionsJSX}
+          <div id={styles.options}>
+            <button onClick={handleAddBrowserOptions}>
+              <img src={plusIcon} alt='add' />
+              Add Option
+            </button>
+          </div>
+        </div>
+      )}
+    </div>  
+  );
+};
+
+export default PuppeteerBrowserSetting;

--- a/src/containers/LeftPanel/TestCase/PuppeteerTestCase.jsx
+++ b/src/containers/LeftPanel/TestCase/PuppeteerTestCase.jsx
@@ -14,12 +14,6 @@ const PuppeteerTestCase = () => {
         <PuppeteerTestMenu dispatchToPuppeteerTestCase={dispatchToPuppeteerTestCase}/>
       </div>
 
-      <div id={styles.testMockSection}>
-        <section  id={styles.testCaseHeader}>
-          <label htmlFor='test-statement'>Test</label>
-        </section>
-      </div>
-
       <DragDropContext>
           <Droppable droppableId='droppable'>
             {provided => (

--- a/src/containers/LeftPanel/TestCase/PuppeteerTestCase.jsx
+++ b/src/containers/LeftPanel/TestCase/PuppeteerTestCase.jsx
@@ -1,12 +1,34 @@
 import React, { useContext } from 'react';
-import styles from '../TestCase/TestCase.module.scss';
 import { PuppeteerTestCaseContext } from '../../../context/puppeteerTestCaseReducer';
 import PuppeteerTestMenu from '../TestMenu/PuppeteerTestMenu';
 import PuppeteerTestStatements from './PuppeteerTestStatements';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
+import { updateStatementsOrder } from '../../../context/puppeteerTestCaseActions';
 
 const PuppeteerTestCase = () => {
-  const [{ puppeteerTestStatement, puppeteerStatements }, dispatchToPuppeteerTestCase] = useContext(PuppeteerTestCaseContext);
+  const [{ puppeteerStatements }, dispatchToPuppeteerTestCase] = useContext(PuppeteerTestCaseContext);
+  
+  const reorder = (list, startIndex, endIndex) => {
+    const result = Array.from(list);
+    const [removed] = result.splice(startIndex, 1);
+    result.splice(endIndex, 0, removed);
+    return result;
+  };
+  
+  const onDragEnd = result => {
+    if (!result.destination) {
+      return;
+    }
+    if (result.destination.index === result.source.index) {
+      return;
+    }
+    const reorderedStatements = reorder(
+      puppeteerStatements,
+      result.source.index,
+      result.destination.index
+    );
+    dispatchToPuppeteerTestCase(updateStatementsOrder(reorderedStatements));
+  };
 
   return (
     <div>
@@ -14,7 +36,7 @@ const PuppeteerTestCase = () => {
         <PuppeteerTestMenu dispatchToPuppeteerTestCase={dispatchToPuppeteerTestCase}/>
       </div>
 
-      <DragDropContext>
+      <DragDropContext onDragEnd={onDragEnd}>
           <Droppable droppableId='droppable'>
             {provided => (
               <div ref={provided.innerRef} {...provided.droppableProps}>

--- a/src/containers/LeftPanel/TestCase/PuppeteerTestStatements.jsx
+++ b/src/containers/LeftPanel/TestCase/PuppeteerTestStatements.jsx
@@ -1,11 +1,20 @@
 import React from 'react';
-
+import PaintTiming from '../PaintTiming/PaintTiming'
 const PuppeteerTestStatements = function puppeteerTestStatements({ puppeteerStatements, dispatchToPuppeteerTestCase }) { 
     return puppeteerStatements.map((statement, i) => {
         switch (statement.type) {
-          case 'form':
+          case 'puppeteerForm':
             return (
               <h1>FORM TESTING</h1>
+            );
+          case 'paintTiming':
+            return (
+              <PaintTiming
+                key={statement.id}
+                paintTiming={statement}
+                index={i}
+                dispatchToPuppeteerTestCase={dispatchToPuppeteerTestCase}
+              />
             );
         default:
             return <></>;

--- a/src/containers/LeftPanel/TestMenu/PuppeteerTestMenu.jsx
+++ b/src/containers/LeftPanel/TestMenu/PuppeteerTestMenu.jsx
@@ -39,7 +39,6 @@ const PuppeteerTestMenu = ({ dispatchToPuppeteerTestCase }) => {
           </button>
           <button data-testid='puppeteerPaintTimingButton' onClick={handleAddPuppeteerPaintTiming}>
             Paint Timing
-            {/* Web Performance (Paint) */}
           </button>
         </div>
       </div>

--- a/src/containers/LeftPanel/TestMenu/PuppeteerTestMenu.jsx
+++ b/src/containers/LeftPanel/TestMenu/PuppeteerTestMenu.jsx
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
 import styles from '../TestMenu/TestMenu.module.scss';
 import PuppeteerTestModal from '../../NavBar/Modals/PuppeteerTestModal';
-import { addPuppeteerForm } from '../../../context/puppeteerTestCaseActions';
+import { addPuppeteerForm, addPuppeteerPaintTiming } from '../../../context/puppeteerTestCaseActions';
 
 const PuppeteerTestMenu = ({ dispatchToPuppeteerTestCase }) => {
   const [isPuppeteerModalOpen, setIsPuppeteerModalOpen] = useState(false);
 
   const openPuppeteerModal = () => {
-    console.log('inside openPuppeteerModal')
     setIsPuppeteerModalOpen(true);
   };
 
@@ -16,8 +15,11 @@ const PuppeteerTestMenu = ({ dispatchToPuppeteerTestCase }) => {
   };
 
   const handleAddPuppeteerForm = e => {
-    console.log('in handleAddPuppeteerForm')
     dispatchToPuppeteerTestCase(addPuppeteerForm());
+  };
+
+  const handleAddPuppeteerPaintTiming = e => {
+    dispatchToPuppeteerTestCase(addPuppeteerPaintTiming());
   };
 
   return (
@@ -34,6 +36,10 @@ const PuppeteerTestMenu = ({ dispatchToPuppeteerTestCase }) => {
         <div id={styles.right}>
           <button data-testid='puppeteerFormButton' onClick={handleAddPuppeteerForm}>
             Form
+          </button>
+          <button data-testid='puppeteerPaintTimingButton' onClick={handleAddPuppeteerPaintTiming}>
+            Paint Timing
+            {/* Web Performance (Paint) */}
           </button>
         </div>
       </div>

--- a/src/containers/LeftPanel/ToolTip/ToolTip.jsx
+++ b/src/containers/LeftPanel/ToolTip/ToolTip.jsx
@@ -35,6 +35,12 @@ const ToolTip = ({ toolTipType }) => {
       'A shortcut to container.querySelector(`[role="${yourRole}"]`) (and it also accepts a TextMatch).',
     TestId:
       'A shortcut to container.querySelector(`[data-testid="${yourId}"]`) (and it also accepts a TextMatch).',
+    LCPTarget: 
+      'The Largest Contentful Paint (LCP) metric reports the render time of the largest content element visible within the viewport. Provide a target value in ms.',
+    FPTarget: 
+      'The First Paint (FP) metric reports the time between navigation and when the browser renders the first pixels to the screen, rendering anything that is visually different from what was on the screen prior to navigation. Provide a target value in ms.',
+    FCPTarget: 
+      "The First Contentful Paint (FCP) metric measures the time from when the page starts loading to when any part of the page's content is rendered on the screen. Provide a target value in ms.",
   };
 
   return <span id={styles.tooltip}>{TOOLTIP_MAP[toolTipType]}</span>;

--- a/src/context/globalReducer.js
+++ b/src/context/globalReducer.js
@@ -5,7 +5,7 @@ export const GlobalContext = createContext(null);
 
 export const globalState = {
   url: null,
-  isProjectLoaded: false,
+  isProjectLoaded: true,
   fileTree: null,
   componentName: '',
   isFileDirectoryOpen: true,

--- a/src/context/globalReducer.js
+++ b/src/context/globalReducer.js
@@ -5,7 +5,7 @@ export const GlobalContext = createContext(null);
 
 export const globalState = {
   url: null,
-  isProjectLoaded: true,
+  isProjectLoaded: false,
   fileTree: null,
   componentName: '',
   isFileDirectoryOpen: true,

--- a/src/context/puppeteerTestCaseActions.js
+++ b/src/context/puppeteerTestCaseActions.js
@@ -6,8 +6,10 @@ export const actionTypes = {
   ADD_PUPPETEER_PAINT_TIMING: 'ADD_PUPPETEER_PAINT_TIMING',
   DELETE_PUPPETEER_PAINT_TIMING: 'DELETE_PUPPETEER_PAINT_TIMING',
   ADD_BROWSER_OPTIONS: 'ADD_BROWSER_OPTIONS',
+  UPDATE_PAINT_TIMING: 'UPDATE_PAINT_TIMING',
   DELETE_BROWSER_OPTION: 'DELETE_BROWSER_OPTION',
   UPDATE_BROWSER_OPTION: 'UPDATE_BROWSER_OPTION',
+  UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
 };
 
 export const togglePuppeteer = () => ({
@@ -55,4 +57,9 @@ export const updateBrowserOption = (id, field, value, optionId) => ({
   field,
   value,
   optionId,
+})
+
+export const updateStatementsOrder = draggableStatements => ({
+  type: actionTypes.UPDATE_STATEMENTS_ORDER,
+  draggableStatements,
 })

--- a/src/context/puppeteerTestCaseActions.js
+++ b/src/context/puppeteerTestCaseActions.js
@@ -2,7 +2,9 @@ export const actionTypes = {
   TOGGLE_PUPPETEER: 'TOGGLE_PUPPETEER',
   CREATE_NEW_PUPPETEER_TEST: 'CREATE_NEW_PUPPETEER_TEST',
   ADD_PUPPETEERFORM: 'ADD_PUPPETEERFORM',
-  DELETE_PUPPETEERFORM: 'DELETE_PUPPETEERFORM',
+  DELETE_PUPPETEER_TEST: 'DELETE_PUPPETEER_TEST',
+  ADD_PUPPETEER_PAINT_TIMING: 'ADD_PUPPETEER_PAINT_TIMING',
+  DELETE_PUPPETEER_PAINT_TIMING: 'DELETE_PUPPETEER_PAINT_TIMING',
 };
 
 export const togglePuppeteer = () => ({
@@ -17,8 +19,12 @@ export const addPuppeteerForm = () => ({
   type: actionTypes.CREATE_NEW_TEST,
 });
 
-export const deletePuppeteerForm = id => ({
-  type: actionTypes.DELETE_PUPPETEERFOR,
+export const deletePuppeteerTest = id => ({
+  type: actionTypes.DELETE_PUPPETEER_TEST,
   id,
+});
+
+export const addPuppeteerPaintTiming = () => ({
+  type: actionTypes.ADD_PUPPETEER_PAINT_TIMING
 });
 

--- a/src/context/puppeteerTestCaseActions.js
+++ b/src/context/puppeteerTestCaseActions.js
@@ -5,6 +5,9 @@ export const actionTypes = {
   DELETE_PUPPETEER_TEST: 'DELETE_PUPPETEER_TEST',
   ADD_PUPPETEER_PAINT_TIMING: 'ADD_PUPPETEER_PAINT_TIMING',
   DELETE_PUPPETEER_PAINT_TIMING: 'DELETE_PUPPETEER_PAINT_TIMING',
+  ADD_BROWSER_OPTIONS: 'ADD_BROWSER_OPTIONS',
+  DELETE_BROWSER_OPTION: 'DELETE_BROWSER_OPTION',
+  UPDATE_BROWSER_OPTION: 'UPDATE_BROWSER_OPTION',
 };
 
 export const togglePuppeteer = () => ({
@@ -28,3 +31,28 @@ export const addPuppeteerPaintTiming = () => ({
   type: actionTypes.ADD_PUPPETEER_PAINT_TIMING
 });
 
+export const addBrowserOption = id => ({
+  type: actionTypes.ADD_BROWSER_OPTIONS,
+  id,
+});
+
+export const deleteBrowserOption = (id, optionId) => ({
+  type: actionTypes.DELETE_BROWSER_OPTION,
+  id,
+  optionId,
+});
+
+export const updatePaintTiming = (id, field, value) => ({
+  type: actionTypes.UPDATE_PAINT_TIMING,
+  id,
+  field,
+  value,
+})
+
+export const updateBrowserOption = (id, field, value, optionId) => ({
+  type: actionTypes.UPDATE_BROWSER_OPTION,
+  id,
+  field,
+  value,
+  optionId,
+})

--- a/src/context/puppeteerTestCaseReducer.js
+++ b/src/context/puppeteerTestCaseReducer.js
@@ -16,6 +16,11 @@ const createPuppeteerForm = () => ({
   type: 'puppeteerForm',
 });
 
+const createPuppeteerPaintTiming = () => ({
+  id: statementId++,
+  type: 'paintTiming',
+});
+
 export const puppeteerTestCaseReducer = (state, action) => {
   Object.freeze(state);
   let puppeteerStatements = [...state.puppeteerStatements];
@@ -33,8 +38,15 @@ export const puppeteerTestCaseReducer = (state, action) => {
         ...state,
         puppeteerStatements,
       };
-    case actionTypes.DELETE_PUPPETEERFORM:
+    case actionTypes.DELETE_PUPPETEER_TEST:
       puppeteerStatements = puppeteerStatements.filter(statement => statement.id !== action.id);
+      return {
+        ...state,
+        puppeteerStatements,
+      };
+
+    case actionTypes.ADD_PUPPETEER_PAINT_TIMING:
+      puppeteerStatements.push(createPuppeteerPaintTiming());
       return {
         ...state,
         puppeteerStatements,

--- a/src/context/puppeteerTestCaseReducer.js
+++ b/src/context/puppeteerTestCaseReducer.js
@@ -19,7 +19,25 @@ const createPuppeteerForm = () => ({
 const createPuppeteerPaintTiming = () => ({
   id: statementId++,
   type: 'paintTiming',
+  describe: '',
+  url: '',
+  browserOptions: [],
+  firstPaintIt: '',
+  firstPaintTime: null,
+  FCPIt: '',
+  FCPtTime: null,
+  LCPPaint: '',
+  LCPTime: null,
+  hasBrowserOption: false,
+  browserOptionId: 0,
 });
+
+
+const createBrowserOption = browserOptionId => ({
+  id: browserOptionId++,
+  optionKey: '',
+  optionValue: '',
+})
 
 export const puppeteerTestCaseReducer = (state, action) => {
   Object.freeze(state);
@@ -58,6 +76,60 @@ export const puppeteerTestCaseReducer = (state, action) => {
         puppeteerStatements: [],
         hasPuppeteer: 0,
       };
+
+    case actionTypes.DELETE_BROWSER_OPTION:
+      puppeteerStatements = puppeteerStatements.map(statement => {
+        if (statement.id === action.id) {
+          statement.browserOptions = statement.browserOptions.filter(option => option.id !== action.optionId);
+        }
+        return statement;
+      });
+      return {
+        ...state,
+        puppeteerStatements,
+      };
+
+    case actionTypes.UPDATE_PAINT_TIMING: 
+    puppeteerStatements = puppeteerStatements.map(statement => {
+      if(statement.id === action.id) {
+        statement[action.field] = action.value
+      }
+      return statement
+    })
+    return {
+      ...state,
+        puppeteerStatements,
+    }
+
+    case actionTypes.ADD_BROWSER_OPTIONS:
+      puppeteerStatements = puppeteerStatements.map(statement => {
+        if (statement.id === action.id) {
+          statement.browserOptions.push(createBrowserOption(statement.browserOptionId));
+        }
+        statement.hasBrowserOption = true
+        statement.browserOptionId++
+        return statement;
+      });
+      return {
+        ...state,
+        puppeteerStatements,
+      };  
+
+    case actionTypes.UPDATE_BROWSER_OPTION:
+      puppeteerStatements = puppeteerStatements.map(statement => {
+        if (statement.id === action.id) {
+          statement.browserOptions.map(option => {
+            if (option.id === action.optionId) {
+              option[action.field] = action.value
+            }
+            return option
+          })
+        }
+        return {
+          ...state,
+          puppeteerStatements,
+        }
+      })
     default:
       return state;
   }

--- a/src/context/puppeteerTestCaseReducer.js
+++ b/src/context/puppeteerTestCaseReducer.js
@@ -4,7 +4,6 @@ import { actionTypes } from './puppeteerTestCaseActions';
 export const PuppeteerTestCaseContext = createContext(null);
 
 export const puppeteerTestCaseState = {
-  puppeteerTestStatement: '',
   puppeteerStatements: [],
   hasPuppeteer: 0,
 };
@@ -26,7 +25,7 @@ const createPuppeteerPaintTiming = () => ({
   firstPaintTime: null,
   FCPIt: '',
   FCPtTime: null,
-  LCPPaint: '',
+  LCPIt: '',
   LCPTime: null,
   hasBrowserOption: false,
   browserOptionId: 0,
@@ -72,7 +71,6 @@ export const puppeteerTestCaseReducer = (state, action) => {
 
     case actionTypes.CREATE_NEW_PUPPETEER_TEST:
       return {
-        puppeteerTestStatement: '',
         puppeteerStatements: [],
         hasPuppeteer: 0,
       };
@@ -82,6 +80,8 @@ export const puppeteerTestCaseReducer = (state, action) => {
         if (statement.id === action.id) {
           statement.browserOptions = statement.browserOptions.filter(option => option.id !== action.optionId);
         }
+
+        if(statement.browserOptions.length === 0) statement.hasBrowserOption = false
         return statement;
       });
       return {
@@ -105,8 +105,8 @@ export const puppeteerTestCaseReducer = (state, action) => {
       puppeteerStatements = puppeteerStatements.map(statement => {
         if (statement.id === action.id) {
           statement.browserOptions.push(createBrowserOption(statement.browserOptionId));
+          statement.hasBrowserOption = true
         }
-        statement.hasBrowserOption = true
         statement.browserOptionId++
         return statement;
       });
@@ -125,11 +125,20 @@ export const puppeteerTestCaseReducer = (state, action) => {
             return option
           })
         }
-        return {
-          ...state,
-          puppeteerStatements,
-        }
+        return statement
       })
+      return {
+        ...state,
+        puppeteerStatements
+      }
+
+    case actionTypes.UPDATE_STATEMENTS_ORDER:
+      puppeteerStatements = [...action.draggableStatements];
+      return {
+        ...state,
+        puppeteerStatements,
+      };
+
     default:
       return state;
   }


### PR DESCRIPTION
Adding support for performance testing using puppeteer

# Features
- displays a form to create a web performance test on three paint timing metrics: 
   - FP
   - FCP
   - LCP
- generates a test file using the form data and exports the file 

<img width="574" alt="Screen Shot 2020-05-12 at 4 44 59 PM" src="https://user-images.githubusercontent.com/46455259/81756291-3387b080-9470-11ea-9058-35eff577537c.png">

_Left Panel Screenshot_


# Planned Enhancements
- add a type check for objects and arrays in the browser option value field
- converting the browser option key field to a single select field from a free text field
