### PR TITLE
fix for [ISSUE#04] and [ISSUE#05]

### DIFF
--- a/src/containers/LeftPanel/TestFile/TestFile.jsx
+++ b/src/containers/LeftPanel/TestFile/TestFile.jsx
@@ -37,7 +37,7 @@ const TestFile = () => {
   const [{ hasEndpoint }, dispatchToEndpointTestCase] = useContext(EndpointTestCaseContext);
   const [{ hasPuppeteer }, dispatchToPuppeteerTestCase] = useContext(PuppeteerTestCaseContext);
   const [{ isTestModalOpen }, dispatchToTestFileModal] = useContext(TestFileModalContext);
-
+  
   const closeTestModal = () => {
     dispatchToTestFileModal(toggleModal());
   };
@@ -138,6 +138,14 @@ const TestFile = () => {
         <section>
           <PuppeteerTestCase />
         </section>
+      )}
+
+      {hasHooks + hasReact + hasHooks + hasPuppeteer + hasEndpoint === 0 && (
+        <div id={styles.testMenu}>
+          <div id={styles.left}>
+            <button id={styles.newTestBtn} onClick={closeTestModal}>New Test +</button>
+          </div>
+        </div>
       )}
 
     </div>

--- a/src/containers/NavBar/Modals/ExportFileModal.jsx
+++ b/src/containers/NavBar/Modals/ExportFileModal.jsx
@@ -22,6 +22,7 @@ const beautify = remote.require('js-beautify');
 
 const ExportFileModal = ({ isExportModalOpen, closeExportModal }) => {
   const [fileName, setFileName] = useState('');
+  const [invalidFileName, setInvalidFileName] = useState(false);
   const [{ projectFilePath }, dispatchToGlobal] = useContext(GlobalContext);
   const [testCase] = useContext(ReactTestCaseContext);
   const [reduxTestCase] = useContext(ReduxTestCaseContext);
@@ -37,9 +38,18 @@ const ExportFileModal = ({ isExportModalOpen, closeExportModal }) => {
   };
 
   const handleClickSave = () => {
+    // file name uniqueness check
+    if (fs.existsSync(projectFilePath + `/__tests__/${fileName}.test.js` )) {
+      setInvalidFileName(true)
+      return
+    }
     generateTestFile();
     exportTestFile();
     closeExportModal();
+    
+    // reset fileName and invalidFileName
+    setInvalidFileName(false);
+    setFileName('');
   };
 
   const generateTestFile = () => {
@@ -696,6 +706,7 @@ const ExportFileModal = ({ isExportModalOpen, closeExportModal }) => {
       <div id={styles.body}>
         <p>File Name</p>
         <input type='text' value={fileName} onChange={handleChangeFileName} />
+        {invalidFileName && <p>A file with the name '{fileName}' already exists.</p>}
         <button id={styles.save} onClick={closeExportModal}>
           Cancel
         </button>

--- a/src/containers/NavBar/Modals/ExportFileModal.module.scss
+++ b/src/containers/NavBar/Modals/ExportFileModal.module.scss
@@ -82,3 +82,33 @@
   display: flex;
   justify-content: center;
 }
+
+#testMenu {
+  padding: 10px;
+  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  width: 98%;
+  margin-bottom: 10px;
+}
+
+#left {
+  float: left;
+  #newTestBtn {
+    height: 40px;
+    width: 110px;
+    opacity: 0.8;
+    font-family: $oxygen;
+    font-size: 14px;
+    border-radius: 5px;
+    border: 0.5px $light-gray solid;
+    color: $mint;
+    background-color: white;
+  }
+
+  #newTestBtn:hover {
+    background-color: $mint;
+    color: white;
+  }
+}
+


### PR DESCRIPTION
**ISSUE#04**
**problem**: user shouldn't be able to export the test file if a file with the same name already exists.
**fix**: adding validation to the handleClickSave to prevent users from overwriting an existing file.

![Screen Shot 2020-05-13 at 3 57 46 PM](https://user-images.githubusercontent.com/46455259/81875049-377d0680-9534-11ea-9792-f0e6779d5b2c.png)

**ISSUE#05**
**problem**: [New Test+] button shouldn't disappear when users close the modal without selecting the type of the test they would like to create.
**fix**: adding a button to render when none of the test types is selected so users can reopen the modal without having to restart the app. 