### PR TITLE
feat Finish functionality of 1st info modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-react-hooks": "^2.5.1",
-    "jest-dom": "^3.5.0",
     "react-test-renderer": "^16.12.0",
     "spectron": "^5.0.0",
     "test-data-bot": "^0.8.0"

--- a/public/electron.js
+++ b/public/electron.js
@@ -1,10 +1,11 @@
-require('dotenv').config()
 const { app, BrowserWindow } = require('electron');
 const path = require('path');
 const isDev = require('electron-is-dev');
 let mainWindow;
 
-if (process.env.NODE_ENV === 'development') {
+if (isDev) console.log('electron version', process.versions.electron)
+
+if (isDev) {
   const { default: installExtension, REACT_DEVELOPER_TOOLS } = require('electron-devtools-installer');
   function addDevTools() {
     app.whenReady().then(() => {
@@ -31,7 +32,7 @@ function createWindow() {
   mainWindow.on('closed', () => (mainWindow = null));
 }
 
-if (process.env.NODE_ENV === 'development') {
+if (isDev) {
   app.on('ready', addDevTools);
 }
 

--- a/src/components/Endpoint/Endpoint.jsx
+++ b/src/components/Endpoint/Endpoint.jsx
@@ -1,10 +1,12 @@
 import React, { useContext } from 'react';
 import styles from '../Endpoint/Endpoint.module.scss';
 import { GlobalContext } from '../../context/reducers/globalReducer';
+import { EndpointTestCaseContext } from '../../context/reducers/endpointTestCaseReducer'
 import {
   deleteEndpoint,
   updateEndpoint,
   updateServerFilePath,
+  openInfoModal,
 } from '../../context/actions/endpointTestCaseActions';
 import { Draggable } from 'react-beautiful-dnd';
 import SearchInput from '../SearchInput/SearchInput';
@@ -13,7 +15,7 @@ const dragIcon = require('../../assets/images/drag-vertical.png');
 
 const Endpoint = ({ endpoint, index, dispatchToEndpointTestCase }) => {
   const [{ filePathMap }] = useContext(GlobalContext);
-
+  const [{modalOpen}] = useContext(EndpointTestCaseContext);
   const handleChangeEndpointFields = (e, field) => {
     let updatedEndpoint = { ...endpoint };
     updatedEndpoint[field] = e.target.value;
@@ -24,7 +26,12 @@ const Endpoint = ({ endpoint, index, dispatchToEndpointTestCase }) => {
     dispatchToEndpointTestCase(deleteEndpoint(endpoint.id));
   };
 
+  const modalOpener = () => {
+    dispatchToEndpointTestCase(openInfoModal())
+  };
+
   return (
+    <div>
     <Draggable draggableId={endpoint.id.toString()} index={index}>
       {provided => (
         <div
@@ -38,8 +45,8 @@ const Endpoint = ({ endpoint, index, dispatchToEndpointTestCase }) => {
           <div id={styles.header}>
             <img src={dragIcon} alt='drag' />
             <h3>Endpoint</h3>
+            <button onClick= {modalOpener}>Example</button>
           </div>
-
 
           <div id={styles.groupFlexbox}>
             <div id={styles.serverInput}>
@@ -112,11 +119,11 @@ const Endpoint = ({ endpoint, index, dispatchToEndpointTestCase }) => {
                 </div>
               </div>
             </div>
- 
-        </div>
-
+         
+        </div> 
       )}
     </Draggable>
+    </div>
   );
 };
 

--- a/src/components/Endpoint/EndpointModal.jsx
+++ b/src/components/Endpoint/EndpointModal.jsx
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react'
+import { closeInfoModal } from '../../context/actions/endpointTestCaseActions';
+import { EndpointTestCaseContext } from '../../context/reducers/endpointTestCaseReducer';
+import ReactModal from 'react-modal';
+import styles from '../../components/Modals/ExportFileModal.module.scss';
+const closeIcon = require('../../assets/images/close.png');
+
+const EndpointModal = () => {
+   const [ {modalOpen} , dispatchToEndpointTestCase] = useContext(EndpointTestCaseContext);
+
+   const closeModal = () => {
+       dispatchToEndpointTestCase(closeInfoModal())
+   }
+
+   const modalStyles = {
+    overlay: {
+      zIndex: 3,
+    },
+  };
+
+    return(
+        <ReactModal
+        className={styles.modal}
+        shouldCloseOnEsc={true}
+        isOpen={modalOpen}
+        // style={modalStyles}
+        >
+            
+            <img src= {closeIcon} onClick ={closeModal}/>
+        </ReactModal>
+        
+    )
+}
+
+export default EndpointModal;

--- a/src/components/Modals/BrowserModal.jsx
+++ b/src/components/Modals/BrowserModal.jsx
@@ -12,7 +12,7 @@ import { setProjectUrl } from '../../context/actions/globalActions';
 const BrowserModal = ({ isBrowserModalOpen, closeBrowserModal }) => {
   const [, dispatchToGlobal] = useContext(GlobalContext);
   const addHttps = url => {
-    if (url.indexOf('http://') == 0 || url.indexOf('https://') == 0) {
+    if (url.indexOf('http://') === 0 || url.indexOf('https://') === 0) {
       return url;
     } else if (url.startsWith('localhost')) {
       url = 'http://' + url;

--- a/src/components/TestCase/EndpointTestCase.jsx
+++ b/src/components/TestCase/EndpointTestCase.jsx
@@ -5,9 +5,9 @@ import { updateEndpointTestStatement, updateStatementsOrder } from '../../contex
 import EndpointTestMenu from '../TestMenu/EndpointTestMenu';
 import EndpointTestStatements from './EndpointTestStatements';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-
+import EndpointModal from '../Endpoint/EndpointModal'
 const EndpointTestCase = () => {
-    const [{ endpointTestStatement, endpointStatements }, dispatchToEndpointTestCase] = useContext(EndpointTestCaseContext);
+    const [{ endpointTestStatement, endpointStatements, modalOpen }, dispatchToEndpointTestCase] = useContext(EndpointTestCaseContext);
 
     const handleUpdateEndpointTestStatements = e => {
         dispatchToEndpointTestCase(updateEndpointTestStatement(e.target.value))
@@ -35,6 +35,9 @@ const EndpointTestCase = () => {
         dispatchToEndpointTestCase(updateStatementsOrder(reorderedStatements));
       };
 
+      let endpointInfoModal = null
+      if (modalOpen) endpointInfoModal = <EndpointModal/>
+
     return (
         <div>
             <div id='head'>
@@ -52,7 +55,7 @@ const EndpointTestCase = () => {
                     />
                 </section>
             </div>
-
+            {endpointInfoModal}
             <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable droppableId='droppable'>
                     {provided => (

--- a/src/context/actions/endpointTestCaseActions.js
+++ b/src/context/actions/endpointTestCaseActions.js
@@ -13,6 +13,8 @@ export const actionTypes = {
     ADD_ENDPOINT: 'ADD_ENDPOINT',
     DELETE_ENDPOINT: 'DELETE_ENDPOINT',
     UPDATE_ENDPOINT: 'UPDATE_ENDPOINT',
+    OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
+    CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
 };
 
 
@@ -74,3 +76,10 @@ export const updateStatementsOrder = draggableStatements => {
       draggableStatements,
     }};
   
+export const openInfoModal = () => {
+    return {type: actionTypes.OPEN_INFO_MODAL,}
+};
+
+export const closeInfoModal = () => {
+    return {type: actionTypes.CLOSE_INFO_MODAL,}
+};

--- a/src/context/reducers/endpointTestCaseReducer.js
+++ b/src/context/reducers/endpointTestCaseReducer.js
@@ -4,6 +4,7 @@ import { actionTypes } from '../actions/endpointTestCaseActions';
 export const EndpointTestCaseContext = createContext(null);
 
 export const endpointTestCaseState = {
+  modalOpen: false,
   endpointTestStatement: '',
   endpointStatements: [],
   hasEndpoint: 0,
@@ -45,6 +46,7 @@ export const endpointTestCaseReducer = (state, action) => {
       return {
         ...state,
         endpointStatements,
+        modalOpen: false,
       };
     case actionTypes.DELETE_ENDPOINT:
       endpointStatements = endpointStatements.filter(statement => statement.id !== action.id);
@@ -92,6 +94,17 @@ export const endpointTestCaseReducer = (state, action) => {
           ...state,
           endpointStatements,
         };
+      case actionTypes.OPEN_INFO_MODAL:
+        return {
+          ...state,
+          modalOpen: true,
+        };
+      case actionTypes.CLOSE_INFO_MODAL:
+        return {
+          ...state,
+          modalOpen: false,
+        };
+
     default:
       return state;
   }

--- a/src/pages/LeftPanel/test/puppeteerLeftPanel.test.tsx
+++ b/src/pages/LeftPanel/test/puppeteerLeftPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, cleanup } from '@testing-library/react';
 import { PuppeteerTestCaseContext } from '../../../context/reducers/puppeteerTestCaseReducer';
 import PuppeteerTestCase from '../../../components/TestCase/PuppeteerTestCase';
 import { TestFileModalContext } from '../../../context/reducers/testFileModalReducer';
-// import 'jest-dom/extend-expect';
+import "@testing-library/jest-dom/extend-expect";
 
 const testFileModal = {
   isTestModalOpen: false,

--- a/src/pages/LeftPanel/test/puppeteerLeftPanel.test.tsx
+++ b/src/pages/LeftPanel/test/puppeteerLeftPanel.test.tsx
@@ -3,7 +3,7 @@ import { render, cleanup } from '@testing-library/react';
 import { PuppeteerTestCaseContext } from '../../../context/reducers/puppeteerTestCaseReducer';
 import PuppeteerTestCase from '../../../components/TestCase/PuppeteerTestCase';
 import { TestFileModalContext } from '../../../context/reducers/testFileModalReducer';
-import 'jest-dom/extend-expect';
+// import 'jest-dom/extend-expect';
 
 const testFileModal = {
   isTestModalOpen: false,

--- a/src/pages/ProjectLoader/ProjectLoader.jsx
+++ b/src/pages/ProjectLoader/ProjectLoader.jsx
@@ -3,12 +3,13 @@ import styles from './ProjectLoader.module.scss';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import OpenFolder from '../../components/OpenFolder/OpenFolderButton';
 import { setProjectUrl } from '../../context/actions/globalActions';
+require('dotenv').config();
 
 const ProjectLoader = () => {
   const [, dispatchToGlobal] = useContext(GlobalContext);
 
   const addHttps = url => {
-    if (url.indexOf('http://') == 0 || url.indexOf('https://') == 0) {
+    if (url.indexOf('http://') === 0 || url.indexOf('https://') === 0) {
       return url;
     } else if (url.startsWith('localhost')) {
       url = 'http://' + url;
@@ -23,6 +24,8 @@ const ProjectLoader = () => {
     const testSiteURL = addHttps(e.target.value);
     dispatchToGlobal(setProjectUrl(testSiteURL));
   };
+  
+  const placehold =  process.env.NODE_ENV === 'development' ? 'Dev mode do not fill out' : 'ex: localhost:3000' 
 
   return (
     <div id={styles.projectLoader}>
@@ -48,7 +51,7 @@ const ProjectLoader = () => {
             <input
               type='text'
               id={styles.url}
-              placeholder='ex: localhost:3000'
+              placeholder= {placehold}
               onChange={handleChangeUrl}
             />
           </div>


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce to Scratch Project? Put an `x` in the boxes that apply. -->
- [ ] Bugfix (change which fixes an issue)
- [x] New feature (change which adds functionality)
- [x] Refactor (change which changes the codebase without affecting its external behavior)
- [x] Non-breaking change (fix or feature that would causes existing functionality to work as expected)
- [ ] Breaking change (fix or feature that would cause existing functionality to __not__ work as expected)
## Purpose
<!--- Describe the problem or feature. Link to the issue(s) fixed by this pull request if applicable. -->
Refactored electron.js, removed deprecated dependency jest-dom, created new modal component that will be later be populated with desired data, added functionality to open and close modal.    
## Approach
<!--- How does your change address the problem? -->
Makes the code a bit cleaner, as well as sets up info modal for stylization etc. It also makes the setup of the other info modals easier.  
## Learning
<!--- Describe the research stage. Link to any blog posts, video, patterns, libraries, addons, or other resources that helped you to solve this problem. -->
Learnt more about Context api, as well as hooks.
https://www.youtube.com/watch?v=cF2lQ_gZeA8&list=PLC3y8-rFHvwisvxhZ135pogtX7_Oe3Q3A  
## Screenshot(s)
<!--- (if applicable--you can delete otherwise) -->
![Screen Shot 2020-08-10 at 8 08 19 PM](https://user-images.githubusercontent.com/63618844/89853083-4714e700-db45-11ea-98cf-caac0712b2ed.png)

<!--- Include a screenshot here if the change you made changes the look of the site in any way! -->