### PR TITLE
Initial clean up

### DIFF
--- a/src/__tests__/globalReducer.test.js
+++ b/src/__tests__/globalReducer.test.js
@@ -179,14 +179,14 @@ describe('Global Reducer works properly', () => {
     });
   });
 
-  it('should handle UPDATE_FILE_SHOW', () => {
-    let action = { type: 'UPDATE_FILE_SHOW', testString: '' };
+  it('should handle UPDATE_FILE', () => {
+    let action = { type: 'UPDATE_FILE', testString: '' };
     expect(globalReducer(initialState, action)).toEqual({
       ...initialState,
       file: '',
     });
     action = {
-      type: 'UPDATE_FILE_SHOW',
+      type: 'UPDATE_FILE',
       testString: `import React from "react";
       import { render, fireEvent } from '@testing-library/react';
       import '@testing-library/jest-dom/extend-expect`,

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -1,3 +1,8 @@
+/*
+ * Handles modals that pop up from pressing buttons "New Test +" or "Run Test",
+ * which render on the top Test Menu component.
+ */
+
 import React from 'react';
 import ReactModal from 'react-modal';
 import styles from './ExportFileModal.module.scss';
@@ -16,7 +21,7 @@ const Modal = ({
     dispatchToMockData,
     dispatchTestCase,
     createTest,
-    closeModal
+    closeModal,
   );
 
   const script = useGenerateScript(title);
@@ -32,7 +37,7 @@ const Modal = ({
       className={styles.modal}
       isOpen={isModalOpen}
       onRequestClose={closeModal}
-      contentLabel='Save?'
+      contentLabel="Save?"
       shouldCloseOnOverlayClick={true}
       shouldCloseOnEsc={true}
       ariaHideApp={false}
@@ -42,28 +47,38 @@ const Modal = ({
         <p>{title === 'New Test' ? title : 'Copy to Terminal'}</p>
       </div>
       <div id={styles.body}>
-        {title === 'New Test' ? (
-          <p id={styles.text}>
-            Do you want to start a new test? All unsaved changes <br /> will be lost.{' '}
-          </p>
-        ) : (
-          <pre>
-            <div className='code-wrapper'>
-              <code ref={codeRef}>{script}</code>
-              <p id={styles.endpoint}>Note if you are using Create React App do not install jest</p>
-            </div>
-          </pre>
-        )}
-        <span id={styles.newTestButtons}>
-          {title === 'New Test' ? (
-            <button id={styles.save} onClick={handleNewTest}>
-              {title}
-            </button>
-          ) : (
-            <button id={styles.save} onClick={handleCopy}>
-              {copySuccess ? 'Copied!' : 'Copy'}
-            </button>
+        {title === 'New Test'
+          ? (
+            <p id={styles.text}>
+              Do you want to start a new test? All unsaved changes
+              <br />
+              will be lost.
+            </p>
+          )
+          : (
+            <pre>
+              <div className="code-wrapper">
+                <code ref={codeRef}>
+                  {script}
+                </code>
+                <p id={styles.endpoint}>
+                  Note if you are using Create React App do not install jest
+                </p>
+              </div>
+            </pre>
           )}
+        <span id={styles.newTestButtons}>
+          {title === 'New Test'
+            ? (
+              <button id={styles.save} onClick={handleNewTest}>
+                {title}
+              </button>
+            )
+            : (
+              <button id={styles.save} onClick={handleCopy}>
+                {copySuccess ? 'Copied!' : 'Copy'}
+              </button>
+            )}
           <button id={styles.save} onClick={closeModal}>
             Cancel
           </button>

--- a/src/components/TestMenu/EndpointTestMenu.tsx
+++ b/src/components/TestMenu/EndpointTestMenu.tsx
@@ -27,7 +27,6 @@ const EndpointTestMenu = () => {
   const [{ projectFilePath, file, exportBool }, dispatchToGlobal] = useContext<any>(GlobalContext);
   const { title, isModalOpen, openModal, openScriptModal, closeModal } = useToggleModal('endpoint');
   const generateTest = useGenerateTest('endpoint', projectFilePath);
-  let valid;
   // Endpoint testing docs url
   const endpointUrl = 'https://www.npmjs.com/package/supertest';
 
@@ -59,8 +58,8 @@ const EndpointTestMenu = () => {
   };
 
   if (exportBool) {
-    valid = validateInputs('endpoint', endpointTestCase);
-    valid ? dispatchToGlobal(setValidCode(true)) : dispatchToGlobal(setValidCode(false));
+    const valid = validateInputs('endpoint', endpointTestCase);
+    dispatchToGlobal(setValidCode(valid));
     dispatchToGlobal(toggleExportBool());
     if (valid && !file) dispatchToGlobal(updateFile(generateTest(endpointTestCase)));
   }

--- a/src/components/TestMenu/HooksTestMenu.tsx
+++ b/src/components/TestMenu/HooksTestMenu.tsx
@@ -18,7 +18,6 @@ import { useToggleModal, validateInputs } from './testMenuHooks';
 const HooksTestMenu = () => {
   // Hooks testing docs url
   const hooksUrl = 'https://react-hooks-testing-library.com/usage/basic-hooks';
-  let valid;
   const [{ hooksTestStatement, hooksStatements }, dispatchToHooksTestCase] = useContext(
     HooksTestCaseContext
   );
@@ -45,16 +44,15 @@ const HooksTestMenu = () => {
   };
 
   if (exportBool) {
-    valid = validateInputs('hooks', hooksStatements);
-    valid ? dispatchToGlobal(setValidCode(true)) : dispatchToGlobal(setValidCode(false));
+    const valid = validateInputs('hooks', hooksStatements);
+    dispatchToGlobal(setValidCode(valid));
     dispatchToGlobal(toggleExportBool());
     if (valid && !file) dispatchToGlobal(updateFile(generateTest(hooksStatements)));
   }
 
   if (!file && exportBool) {
-    validateInputs('hooks', hooksStatements)
-      ? dispatchToGlobal(setValidCode(true))
-      : dispatchToGlobal(setValidCode(false));
+    const valid = validateInputs('hooks', hooksStatements);
+    dispatchToGlobal(setValidCode(valid));
     dispatchToGlobal(updateFile(generateTest({ hooksTestStatement, hooksStatements })));
   }
   return (

--- a/src/context/actions/globalActions.js
+++ b/src/context/actions/globalActions.js
@@ -16,7 +16,7 @@ export const actionTypes = {
   UPDATE_FILE_SHOW: 'UPDATE_FILE_SHOW',
   OPEN_BROWSER_DOCS: 'OPEN_BROWSER_DOCS',
   NEW_TEST_CLOSE_BROWSER_DOCS: 'NEW_TEST_CLOSE_BROWSER_DOCS',
-  EXPORT: 'EXPORT',
+  TOGGLE_EXPORT_BOOL: 'TOGGLE_EXPORT_BOOL',
   SET_FILE_PATH: 'SET_FILE_PATH',
   SET_VALID_CODE: 'SET_VALID_CODE',
 };
@@ -90,7 +90,7 @@ export const openBrowserDocs = (docsUrl) => ({
 });
 
 export const toggleExportBool = () => ({
-  type: actionTypes.EXPORT,
+  type: actionTypes.TOGGLE_EXPORT_BOOL,
 });
 
 export const setFilePath = (filePath) => ({

--- a/src/context/actions/globalActions.js
+++ b/src/context/actions/globalActions.js
@@ -13,7 +13,7 @@ export const actionTypes = {
   //added
   SET_TEST_CASE: 'SET_TEST_CASE',
   TOGGLE_MODAL: 'TOGGLE_MODAL',
-  UPDATE_FILE_SHOW: 'UPDATE_FILE_SHOW',
+  UPDATE_FILE: 'UPDATE_FILE',
   OPEN_BROWSER_DOCS: 'OPEN_BROWSER_DOCS',
   NEW_TEST_CLOSE_BROWSER_DOCS: 'NEW_TEST_CLOSE_BROWSER_DOCS',
   TOGGLE_EXPORT_BOOL: 'TOGGLE_EXPORT_BOOL',
@@ -80,7 +80,7 @@ export const toggleModal = () => ({
 });
 
 export const updateFile = (testString) => ({
-  type: actionTypes.UPDATE_FILE_SHOW,
+  type: actionTypes.UPDATE_FILE,
   testString,
 });
 

--- a/src/context/actions/globalActions.js
+++ b/src/context/actions/globalActions.js
@@ -102,7 +102,7 @@ export const resetToProjectUrl = () => ({
   type: actionTypes.NEW_TEST_CLOSE_BROWSER_DOCS,
 });
 
-export const setValidCode = (verdict) => ({
+export const setValidCode = (validCode) => ({
   type: actionTypes.SET_VALID_CODE,
-  validCode: verdict,
+  validCode,
 });

--- a/src/context/actions/globalActions.js
+++ b/src/context/actions/globalActions.js
@@ -15,7 +15,7 @@ export const actionTypes = {
   TOGGLE_MODAL: 'TOGGLE_MODAL',
   UPDATE_FILE: 'UPDATE_FILE',
   OPEN_BROWSER_DOCS: 'OPEN_BROWSER_DOCS',
-  NEW_TEST_CLOSE_BROWSER_DOCS: 'NEW_TEST_CLOSE_BROWSER_DOCS',
+  RESET_TO_PROJECT_URL: 'RESET_TO_PROJECT_URL', // formerly NEW_TEST_CLOSE_BROWSER_DOCS
   TOGGLE_EXPORT_BOOL: 'TOGGLE_EXPORT_BOOL',
   SET_FILE_PATH: 'SET_FILE_PATH',
   SET_VALID_CODE: 'SET_VALID_CODE',
@@ -89,6 +89,10 @@ export const openBrowserDocs = (docsUrl) => ({
   docsUrl,
 });
 
+export const resetToProjectUrl = () => ({
+  type: actionTypes.RESET_TO_PROJECT_URL,
+});
+
 export const toggleExportBool = () => ({
   type: actionTypes.TOGGLE_EXPORT_BOOL,
 });
@@ -96,10 +100,6 @@ export const toggleExportBool = () => ({
 export const setFilePath = (filePath) => ({
   type: actionTypes.SET_FILE_PATH,
   filePath,
-});
-
-export const resetToProjectUrl = () => ({
-  type: actionTypes.NEW_TEST_CLOSE_BROWSER_DOCS,
 });
 
 export const setValidCode = (validCode) => ({

--- a/src/context/reducers/globalReducer.js
+++ b/src/context/reducers/globalReducer.js
@@ -125,7 +125,8 @@ export const globalReducer = (state, action) => {
         isRightPanelOpen: true,
         rightPanelDisplay: 'browserView',
       };
-    case actionTypes.NEW_TEST_CLOSE_BROWSER_DOCS:
+    case actionTypes.RESET_TO_PROJECT_URL:
+      // formerly NEW_TEST_CLOSE_BROWSER_DOCS
       const urlReset = state.projectUrl;
       return {
         ...state,

--- a/src/context/reducers/globalReducer.js
+++ b/src/context/reducers/globalReducer.js
@@ -50,10 +50,9 @@ export const globalReducer = (state, action) => {
       };
 
     case actionTypes.TOGGLE_FILE_DIRECTORY:
-      const isFileDirectoryOpen = !state.isFileDirectoryOpen;
       return {
         ...state,
-        isFileDirectoryOpen,
+        isFileDirectoryOpen: !state.isFileDirectoryOpen,
       };
     case actionTypes.CLOSE_RIGHT_PANEL:
       const projUrl = state.projectUrl;
@@ -135,10 +134,9 @@ export const globalReducer = (state, action) => {
         projectUrl: urlReset,
       };
     case actionTypes.TOGGLE_EXPORT_BOOL:
-      let exportBool = !state.exportBool;
       return {
         ...state,
-        exportBool,
+        exportBool: !state.exportBool,
       };
     case actionTypes.SET_FILE_PATH:
       const filePath = action.filePath;
@@ -147,9 +145,10 @@ export const globalReducer = (state, action) => {
         filePath,
       };
     case actionTypes.SET_VALID_CODE:
+      const validCode = action.validCode;
       return {
         ...state,
-        validCode: action.validCode,
+        validCode,
       };
     default:
       return state;

--- a/src/context/reducers/globalReducer.js
+++ b/src/context/reducers/globalReducer.js
@@ -112,10 +112,10 @@ export const globalReducer = (state, action) => {
       };
     //
     case actionTypes.UPDATE_FILE:
-      const updatedFile = action.testString;
+      const file = action.testString;
       return {
         ...state,
-        file: updatedFile,
+        file,
       };
     case actionTypes.OPEN_BROWSER_DOCS:
       const docsUrl = action.docsUrl;

--- a/src/context/reducers/globalReducer.js
+++ b/src/context/reducers/globalReducer.js
@@ -132,7 +132,7 @@ export const globalReducer = (state, action) => {
         url: urlReset,
         projectUrl: urlReset,
       };
-    case actionTypes.EXPORT:
+    case actionTypes.TOGGLE_EXPORT_BOOL:
       let exportBool = !state.exportBool;
       return {
         ...state,

--- a/src/context/reducers/globalReducer.js
+++ b/src/context/reducers/globalReducer.js
@@ -111,7 +111,7 @@ export const globalReducer = (state, action) => {
         isTestModalOpen: !state.isTestModalOpen,
       };
     //
-    case actionTypes.UPDATE_FILE_SHOW:
+    case actionTypes.UPDATE_FILE:
       const updatedFile = action.testString;
       return {
         ...state,

--- a/src/context/reducers/globalReducer.js
+++ b/src/context/reducers/globalReducer.js
@@ -37,9 +37,10 @@ export const globalReducer = (state, action) => {
         projectUrl: url,
       };
     case actionTypes.LOAD_PROJECT:
+      const isProjectLoaded = action.load;
       return {
         ...state,
-        isProjectLoaded: action.load,
+        isProjectLoaded,
       };
     case actionTypes.CREATE_FILE_TREE:
       const fileTree = action.fileTree;


### PR DESCRIPTION
Hello team!

This pull request consists of general code clean-up in:
```
- src/context/actions/globalActions.js
- src/context/reducers/globalReducer.js
- src/components/TestMenu
- src/components/Modals/Modal.jsx
- src/context/useGenerateTest.jsx
```

**`globalActions.js`**
- actionTypes wording was updated for 3 actions, so as to create consistency between SNAKE_CASE and camelCase
  - namely, `UPDATE_FILE_SHOW`, `NEW_TEST_CLOSE_BROWSER_DOCS`, `EXPORT` were
renamed to `UPDATE_FILE`, `RESET_TO_PROJECT_URL`,  `TOGGLE_EXPORT_BOOL` respectively.
  - by consequence, I also updated `src/__tests__/globalReducer.test.js`.
- The order of actions were rearranged so as to be consistent with `globalReducer.js`.

**`globalReducer.js`**
- SNAKE_CASE actions were updated to reflect the first change above.
- Stylistic choices were more strictly enforced.
  - Toggle actions where the state variable alternates between booleans were updated to handle that _within_ the return statement, rather than through creating another variable in memory.
  - ES6 shorthand (re: key and value of the same name being initialized in an object) is implemented wherever possible within return statements.

**`TestMenu`**
- Directory summary:
  - `leftPanelEndpoint.test.js`: Testing.
  - `TestMenu.module.scss`: Styling.
  - `testMenuHooks.js`: Exports 2 functions:
    - `useToggleModal`: responsible for toggling `Modal.jsx`, connected to all 5 TestMenu components.
    - `validateInputs`: connected to `HooksTestMenu.tsx` and `EndpointTestMenu.tsx`.
  - 5 `TestMenu` files for 5 test types: endpoint, hooks, puppeteer, react, redux.
    - These render the "Test Menu" for each type of test.
    - Every file except `ReactTestMenu,jsx` is in .tsx format.
    - Below is an image of what's rendered by `ReduxTestMenu.tsx`; All other files render similar content.
    ![Screen Shot 2021-03-07 at 10 01 46 PM](https://user-images.githubusercontent.com/73931127/110281364-71227080-7f91-11eb-87a7-dc81711d9a2c.png)
- Changes made:
    - In `HooksTestMenu.tsx` and `EndpointTestMenu.tsx`, unnecessary ternary operators were removed where `validateInputs()` and `dispatchToGlobal(setValidCode())` are called.

**`Modal.jsx`**
- Renders these two modals.
![Screen Shot 2021-03-07 at 10 19 04 PM](https://user-images.githubusercontent.com/73931127/110282331-27d32080-7f93-11eb-8e5b-cd78172fed5c.png)
- Changes made:
  - Added a description at top, since the file name is not descriptive.
  - Rearranged ternary operator spacing for legibility.

**`useGenerateTest.jsx`**
- No changes were made, however, it was hefty and crucial to look at during this process due to this file's connection with the 5 TestMenu files.

As always, I'm looking forward to our code review.

Best,
Annie S