### PR TITLE
Fix accessibility context connection

### DIFF
--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -45,13 +45,16 @@ const AccTestCase = () => {
   };
 
   return (
-    
+    <AccTestCaseContext.Provider value={[accTestCase, dispatchToAccTestCase]}>
+  
       <div id={styles.AccTestCase}>
+
         <div id='head'>
           <AccTestMenu />
         </div>
+
         <section id={styles.testCaseHeader}>
-        <label htmlFor='fileImport'>Import File From</label>
+          <label htmlFor='fileImport'>Import File From</label>
           <div id={styles.labelInput} style={{ width: '80%' }}>
             <SearchInput
               options={Object.keys(filePathMap)}
@@ -61,18 +64,21 @@ const AccTestCase = () => {
             />
           </div>
 
-        <DecribeRenderer
-          dispatcher={dispatchToAccTestCase}
-          draggableStatements={draggableStatements}
-          describeBlocks={describeBlocks}
-          itStatements={itStatements}
-          statements={statements}
-          handleChangeDescribeText={handleChangeDescribeText}
-          handleChangeItStatementText={handleChangeItStatementText}
-          type='acc'
-        />
+          <DecribeRenderer
+            dispatcher={dispatchToAccTestCase}
+            draggableStatements={draggableStatements}
+            describeBlocks={describeBlocks}
+            itStatements={itStatements}
+            statements={statements}
+            handleChangeDescribeText={handleChangeDescribeText}
+            handleChangeItStatementText={handleChangeItStatementText}
+            type='acc'
+          />
         </section>
+
       </div>
+
+    </AccTestCaseContext.Provider>
   );
 };
 export default AccTestCase;

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -11,7 +11,6 @@ import SearchInput from '../SearchInput/SearchInput';
 // ### this ties in with Sharon's code - did not create a file ### VERIFY PATH
 import AccTestMenu from '../TestMenu/AccTestMenu';
 
-
 import DecribeRenderer from '../AccTestComponent/DescribeRenderer/DescribeRenderer';
 import { updateImportFilePath } from '../../context/actions/accTestCaseActions';
 import {
@@ -24,11 +23,11 @@ const AccTestCase = () => {
   // changes to pull down context
   const [accTestCase, dispatchToAccTestCase] = useReducer(
     accTestCaseReducer,
-    accTestCaseState
+    accTestCaseState,
   );
-  
+
   const { describeBlocks, itStatements, statements } = accTestCase;
-  
+
   const [{ filePathMap }] = useContext(GlobalContext);
   const draggableStatements = describeBlocks.allIds;
 
@@ -46,15 +45,15 @@ const AccTestCase = () => {
 
   return (
     <AccTestCaseContext.Provider value={[accTestCase, dispatchToAccTestCase]}>
-  
+
       <div id={styles.AccTestCase}>
 
-        <div id='head'>
+        <div id="head">
           <AccTestMenu />
         </div>
 
         <section id={styles.testCaseHeader}>
-          <label htmlFor='fileImport'>Import File From</label>
+          <label htmlFor="fileImport">Import File From</label>
           <div id={styles.labelInput} style={{ width: '80%' }}>
             <SearchInput
               options={Object.keys(filePathMap)}
@@ -72,7 +71,7 @@ const AccTestCase = () => {
             statements={statements}
             handleChangeDescribeText={handleChangeDescribeText}
             handleChangeItStatementText={handleChangeItStatementText}
-            type='acc'
+            type="acc"
           />
         </section>
 

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -20,10 +20,8 @@ import {
 } from '../../context/reducers/accTestCaseReducer';
 
 const AccTestCase = () => {
-  // changes to pull down context
-  const [accTestCase, dispatchToAccTestCase] = useReducer(
-    accTestCaseReducer,
-    accTestCaseState,
+  const [accTestCase, dispatchToAccTestCase] = useContext(
+    AccTestCaseContext,
   );
 
   const { describeBlocks, itStatements, statements } = accTestCase;
@@ -44,40 +42,36 @@ const AccTestCase = () => {
   };
 
   return (
-    <AccTestCaseContext.Provider value={[accTestCase, dispatchToAccTestCase]}>
+    <div id={styles.AccTestCase}>
 
-      <div id={styles.AccTestCase}>
-
-        <div id="head">
-          <AccTestMenu />
-        </div>
-
-        <section id={styles.testCaseHeader}>
-          <label htmlFor="fileImport">Import File From</label>
-          <div id={styles.labelInput} style={{ width: '80%' }}>
-            <SearchInput
-              options={Object.keys(filePathMap)}
-              dispatch={dispatchToAccTestCase}
-              action={updateImportFilePath}
-              filePathMap={filePathMap}
-            />
-          </div>
-
-          <DecribeRenderer
-            dispatcher={dispatchToAccTestCase}
-            draggableStatements={draggableStatements}
-            describeBlocks={describeBlocks}
-            itStatements={itStatements}
-            statements={statements}
-            handleChangeDescribeText={handleChangeDescribeText}
-            handleChangeItStatementText={handleChangeItStatementText}
-            type="acc"
-          />
-        </section>
-
+      <div id="head">
+        <AccTestMenu />
       </div>
 
-    </AccTestCaseContext.Provider>
+      <section id={styles.testCaseHeader}>
+        <label htmlFor="fileImport">Import File From</label>
+        <div id={styles.labelInput} style={{ width: '80%' }}>
+          <SearchInput
+            options={Object.keys(filePathMap)}
+            dispatch={dispatchToAccTestCase}
+            action={updateImportFilePath}
+            filePathMap={filePathMap}
+          />
+        </div>
+
+        <DecribeRenderer
+          dispatcher={dispatchToAccTestCase}
+          draggableStatements={draggableStatements}
+          describeBlocks={describeBlocks}
+          itStatements={itStatements}
+          statements={statements}
+          handleChangeDescribeText={handleChangeDescribeText}
+          handleChangeItStatementText={handleChangeItStatementText}
+          type="acc"
+        />
+      </section>
+
+    </div>
   );
 };
 export default AccTestCase;


### PR DESCRIPTION
# Fix accessibility context connection
### Summary of Changes

Hello team,

In this PR, I only touched one file, `AccTestCase`.
- Cleaned up styling (e.g. trailing spaces, single-quote).
- Styled the return statement into hopefully a more readable, intuitive structure (using indentation and spacing).
- **Most importantly,** ~I wrapped the returned components in a Context.Provider component, in order to subscribe child components to the shared context, and let state flow downwards.~
- **After code review, I undid the change above, and instead, implemented the useContext hook.**

This fixed the functionality of all the child components of `AccTestCase` (broken items noted in #5 comments); all buttons and input fields alter state as intended, _except_ the "Import File From" input area.