### PR TITLE
"Run Test" script added re: accessibility

### DIFF
--- a/src/components/Modals/modalHooks.js
+++ b/src/components/Modals/modalHooks.js
@@ -38,6 +38,12 @@ export function useNewTest(dispatchToMockData, dispatchTestCase, createTest, clo
 export function useGenerateScript(test) {
   const [{ projectFilePath }] = useContext(GlobalContext);
   switch (test) {
+    case 'acc':
+      return (
+        `cd ${projectFilePath}\n` +
+        'npm i -D axe-core regenerator-runtime jest\n' +
+        'jest'
+      );
     case 'react':
       return (
         `cd ${projectFilePath}\n` +


### PR DESCRIPTION
# "Run Test" script added re: accessibility
### Summary of Changes
Added an 'acc' case to the switch statement in `modalHooks.js`. In-app testing shows expected results, see below.

<img width="515" alt="'Run Test' version of Modal in accTestCase" src="https://user-images.githubusercontent.com/73931127/111081555-22109a00-84c1-11eb-8939-4ec125651422.png">

Note: I chose the last command to be 'jest' rather than 'npm run test' like other cases, because 'jest' is more of a universal command than 'npm run test', which relies on the assumption that the users' package.json is configured with a script that looks like: `"test": "jest"`. Let's talk about this choice at code review!