### PR TITLE
Axe Violations Nuance

### DIFF
--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -848,17 +848,17 @@ function useGenerateTest(test, projectFilePath) {
                 console.log('Congrats! Keep up the good work, you have 0 known violations!');
               } else {
                 violations.forEach(axeViolation => {
-                  console.log('-------');
-                  const whereItFailed = axeViolation.nodes[0].html;
-                  // const failureSummary = axeViolation.nodes[0].failureSummary;
+                  const whereItFailed = axeViolation.nodes.map(node => node.html);
+                  // const failureSummary = axeViolation.nodes.map(node => node.failureSummary);
             
                   const { description, help, helpUrl } = axeViolation;
         
-                  console.log('TEST DESCRIPTION: ', description,
-                  'ISSUE: ', help,
-                  'MORE INFO: ', helpUrl,
-                  'WHERE IT FAILED: ', whereItFailed,
-                  //'how to fix: ', failureSummary
+                  console.log('---------',
+                    '\\nTEST DESCRIPTION: ', description,
+                    '\\nISSUE: ', help,
+                    '\\nMORE INFO: ', helpUrl,
+                    '\\nWHERE IT FAILED: ', whereItFailed,
+                    // '\\nhow to fix: ', failureSummary
                   );
                 });
               }


### PR DESCRIPTION
Hey Team,

This PR is short and sweet, so I won't follow our typical PR format. I changed the `useGenerateTest` file so that axe tests will show **all** violations' details, rather than only the first violation's information. While doing so, I noticed some styling of the console log that could be optimized, such as spacing, so I went ahead and fixed that while I was in there.

I look forward to our review,
Annie