### PR TITLE
Implement Drag and Drop (DnD) in React Test Case

### DIFF
--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -36,14 +36,14 @@ const DescribeRenderer = ({
   return describeBlocks.allIds.map((id, i) => {
     return (
       <Draggable
-        draggableId={id.toString()}
+        key={id}
+        draggableId={id}
         index={i}
         type="describe"
       >
         {(provided) => (
           <div
             id={styles.describeBlock}
-            key={i}
             ref={provided.innerRef}
             {...provided.draggableProps}
             {...provided.dragHandleProps}

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -12,7 +12,7 @@ const DescribeRenderer = ({
   describeBlocks,
   itStatements,
   statements,
-  draggableStatements,
+  // draggableStatements,
   handleChangeDescribeText,
   handleChangeItStatementText,
   type,
@@ -34,7 +34,7 @@ const DescribeRenderer = ({
     dispatcher(addItstatement(describeId));
   };
 
-  return draggableStatements.map((id, i) => {
+  return describeBlocks.allIds.map((id, i) => {
     return (
       <div id={styles.describeBlock} key={i}>
         <label htmlFor='describe-label' className={styles.describeLabel}>

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from 'react';
-import ItRenderer from '../ItRenderer/ItRenderer';
-// import { Draggable } from 'react-beautiful-dnd';
 import cn from 'classnames';
+import { Draggable } from 'react-beautiful-dnd';
+import ItRenderer from '../ItRenderer/ItRenderer';
 import styles from './DescribeRenderer.module.scss';
 import { deleteDescribeBlock, addItstatement } from '../../../context/actions/reactTestCaseActions';
 
@@ -36,72 +36,31 @@ const DescribeRenderer = ({
 
   return describeBlocks.allIds.map((id, i) => {
     return (
-      <div id={styles.describeBlock} key={i}>
-        <label htmlFor='describe-label' className={styles.describeLabel}>
-          Describe Block
-        </label>
-
-        <i
-          onClick={deleteDescribeBlockHandleClick}
-          id={id}
-          className={cn('far fa-window-close', styles.describeClose)}
-        ></i>
-        <input
-          ref={testDescription}
-          id={id}
-          className={styles.describeInput}
-          name='describe-label'
-          type='text'
-          placeholder={'The component has basic functionality'}
-          value={describeBlocks.byId[id].text || ''}
-          onChange={handleChangeDescribeText}
-        />
-        <div className={styles.separator}></div>
-        <ItRenderer
-          type={type}
-          key={`it-${id}-${i}`}
-          itStatements={itStatements}
-          statements={statements}
-          describeId={id}
-          handleChangeItStatementText={handleChangeItStatementText}
-        />
-        <div className={styles.buttonContainer}>
-          <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>
-            +It Statement
-          </button>
-        </div>
-      </div>
-    );
-  });
-};
-
-export default DescribeRenderer;
-
-{
-  /* <Draggable draggableId={`draggable-${id}-${i}`} index={i}>
+      <Draggable draggableId={id.toString()} index={i}>
         {(provided) => (
           <div
+            id={styles.describeBlock}
+            key={i}
             ref={provided.innerRef}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
-            id={styles.describeBlock}
-            className={styles.describeBlock}
           >
             <label htmlFor='describe-label' className={styles.describeLabel}>
               Describe Block
             </label>
+
             <i
               onClick={deleteDescribeBlockHandleClick}
               id={id}
               className={cn('far fa-window-close', styles.describeClose)}
             ></i>
             <input
+              ref={testDescription}
               id={id}
               className={styles.describeInput}
               name='describe-label'
               type='text'
               placeholder={'The component has basic functionality'}
-              defaultValue={''}
               value={describeBlocks.byId[id].text || ''}
               onChange={handleChangeDescribeText}
             />
@@ -115,9 +74,16 @@ export default DescribeRenderer;
               handleChangeItStatementText={handleChangeItStatementText}
             />
             <div className={styles.buttonContainer}>
-              <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>+It Statement</button>
+              <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>
+                +It Statement
+              </button>
             </div>
           </div>
+
         )}
-      </Draggable> */
-}
+      </Draggable>
+    );
+  });
+};
+
+export default DescribeRenderer;

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -70,14 +70,15 @@ const DescribeRenderer = ({
             <div className={styles.separator}></div>
 
             <Droppable
-              droppableId="droppableReactIt"
+              droppableId={"droppableReactIt" + id}
               type={id}
             >
-              {(provided) => (
+              {(innerProvided) => (
                 <div
-                  ref={provided.innerRef}
-                  {...provided.droppableProps}
+                  ref={innerProvided.innerRef}
+                  {...innerProvided.droppableProps}
                 >
+                  {/* {JSON.stringify(provided)} */}
                   <ItRenderer
                     type={type}
                     key={`it-${id}-${i}`}
@@ -86,7 +87,7 @@ const DescribeRenderer = ({
                     describeId={id}
                     handleChangeItStatementText={handleChangeItStatementText}
                   />
-                  {provided.placeholder}
+                  {innerProvided.placeholder}
                 </div>
               )}
             </Droppable>

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -36,7 +36,11 @@ const DescribeRenderer = ({
 
   return describeBlocks.allIds.map((id, i) => {
     return (
-      <Draggable draggableId={id.toString()} index={i}>
+      <Draggable
+        draggableId={id.toString()}
+        index={i}
+        type="describe"
+      >
         {(provided) => (
           <div
             id={styles.describeBlock}
@@ -66,7 +70,10 @@ const DescribeRenderer = ({
             />
             <div className={styles.separator}></div>
 
-            <Droppable droppableId="droppableReactIt">
+            <Droppable
+              droppableId="droppableReactIt"
+              type={id}
+            >
               {(provided) => (
                 <div
                   ref={provided.innerRef}

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react';
 import cn from 'classnames';
-import { Draggable } from 'react-beautiful-dnd';
+import { Draggable, Droppable } from 'react-beautiful-dnd';
 import ItRenderer from '../ItRenderer/ItRenderer';
 import styles from './DescribeRenderer.module.scss';
 import { deleteDescribeBlock, addItstatement } from '../../../context/actions/reactTestCaseActions';
@@ -65,14 +65,24 @@ const DescribeRenderer = ({
               onChange={handleChangeDescribeText}
             />
             <div className={styles.separator}></div>
-            <ItRenderer
-              type={type}
-              key={`it-${id}-${i}`}
-              itStatements={itStatements}
-              statements={statements}
-              describeId={id}
-              handleChangeItStatementText={handleChangeItStatementText}
-            />
+
+            <Droppable droppableId="droppableReactIt">
+              {(provided) => (
+                <div
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                >
+                  <ItRenderer
+                    type={type}
+                    key={`it-${id}-${i}`}
+                    itStatements={itStatements}
+                    statements={statements}
+                    describeId={id}
+                    handleChangeItStatementText={handleChangeItStatementText}
+                  />
+                </div>
+              )}
+            </Droppable>
             <div className={styles.buttonContainer}>
               <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>
                 +It Statement

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -80,6 +80,7 @@ const DescribeRenderer = ({
                     describeId={id}
                     handleChangeItStatementText={handleChangeItStatementText}
                   />
+                  {provided.placeholder}
                 </div>
               )}
             </Droppable>

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -12,7 +12,6 @@ const DescribeRenderer = ({
   describeBlocks,
   itStatements,
   statements,
-  // draggableStatements,
   handleChangeDescribeText,
   handleChangeItStatementText,
   type,

--- a/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
+++ b/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
@@ -47,14 +47,14 @@ const ItRenderer = ({
 
   return filteredIds.map((id, i) => (
     <Draggable
-      draggableId={id.toString()}
+      key={id}
+      draggableId={id}
       index={i}
       type={id}
     >
       {(provided) => (
         <div
           id={styles.ItRenderer}
-          key={describeId + id}
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}

--- a/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
+++ b/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
@@ -21,11 +21,6 @@ const ItRenderer = ({
 }) => {
   const [, dispatchToReactTestCase] = useContext(ReactTestCaseContext);
 
-  // filter out ids not belonging to the correct describe block
-  const filteredIds = itStatements.allIds.filter((id) => {
-    return itStatements.byId[id].describeId === describeId;
-  });
-
   const addRenderHandleClick = (e) => {
     const itId = e.target.id;
     dispatchToReactTestCase(addRender(describeId, itId));
@@ -43,9 +38,8 @@ const ItRenderer = ({
     const itId = e.target.id;
     dispatchToReactTestCase(addAssertion(describeId, itId));
   };
-  
 
-  return filteredIds.map((id, i) => (
+  return itStatements.allIds[describeId].map((id, i) => (
     <Draggable
       key={id}
       draggableId={id}

--- a/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
+++ b/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
@@ -50,7 +50,7 @@ const ItRenderer = ({
       key={id}
       draggableId={id}
       index={i}
-      type={id}
+      type={describeId}
     >
       {(provided) => (
         <div

--- a/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
+++ b/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import cn from 'classnames';
+import { Draggable } from 'react-beautiful-dnd';
 import ReactTestStatements from '../../TestCase/ReactTestStatements';
 import CustomInput from '../CustomInput/CustomInput';
 import {
@@ -45,46 +46,56 @@ const ItRenderer = ({
   
 
   return filteredIds.map((id, i) => (
-    <div id={styles.ItRenderer} key={i}>
-      <i
-        onClick={deleteItStatementHandleClick}
-        id={id}
-        className={cn(styles.itClose, 'far fa-window-close')}
-      ></i>
-      <CustomInput
-        key={`input-${id}-${i}`}
-        id={id}
-        label={'The component should...'}
-        placeholder={'Button component renders correctly...'}
-        value={itStatements.byId[id].text}
-        handleChange={handleChangeItStatementText}
-      />
-      <hr />
-      <ReactTestStatements
-        key={`statement-${id}-${i}`}
-        statements={statements}
-        itId={id}
-        describeId={describeId}
-      />
-      <div>
-        {type === 'react' && (
-          <div className={styles.buttonsContainer}>
-            <button id={id} onClick={addRenderHandleClick} className={styles.reactButton}>
-              <i className='fas fa-plus'></i>
-              Render
-            </button>
-            <button id={id} onClick={addActionHandleClick} className={styles.reactButton}>
-              <i className='fas fa-plus'></i>
-              Action
-            </button>
-            <button id={id} onClick={addAssertionHandleClick} className={styles.reactButton}>
-              <i className='fas fa-plus'></i>
-              Assertion
-            </button>
+    <Draggable draggableId={id.toString()} index={i}>
+      {(provided) => (
+        <div
+          id={styles.ItRenderer}
+          key={describeId + id}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          <i
+            onClick={deleteItStatementHandleClick}
+            id={id}
+            className={cn(styles.itClose, 'far fa-window-close')}
+          ></i>
+          <CustomInput
+            key={`input-${id}-${i}`}
+            id={id}
+            label={'The component should...'}
+            placeholder={'Button component renders correctly...'}
+            value={itStatements.byId[id].text}
+            handleChange={handleChangeItStatementText}
+          />
+          <hr />
+          <ReactTestStatements
+            key={`statement-${id}-${i}`}
+            statements={statements}
+            itId={id}
+            describeId={describeId}
+          />
+          <div>
+            {type === 'react' && (
+              <div className={styles.buttonsContainer}>
+                <button id={id} onClick={addRenderHandleClick} className={styles.reactButton}>
+                  <i className='fas fa-plus'></i>
+                  Render
+                </button>
+                <button id={id} onClick={addActionHandleClick} className={styles.reactButton}>
+                  <i className='fas fa-plus'></i>
+                  Action
+                </button>
+                <button id={id} onClick={addAssertionHandleClick} className={styles.reactButton}>
+                  <i className='fas fa-plus'></i>
+                  Assertion
+                </button>
+              </div>
+            )}
           </div>
-        )}
-      </div>
-    </div>
+        </div>
+      )}
+    </Draggable>
   ));
 };
 

--- a/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
+++ b/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
@@ -50,7 +50,7 @@ const ItRenderer = ({
       key={id}
       draggableId={id}
       index={i}
-      type={describeId}
+      // type={describeId} // passed down automatically
     >
       {(provided) => (
         <div

--- a/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
+++ b/src/components/ReactTestComponent/ItRenderer/ItRenderer.jsx
@@ -46,7 +46,11 @@ const ItRenderer = ({
   
 
   return filteredIds.map((id, i) => (
-    <Draggable draggableId={id.toString()} index={i}>
+    <Draggable
+      draggableId={id.toString()}
+      index={i}
+      type={id}
+    >
       {(provided) => (
         <div
           id={styles.ItRenderer}

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -135,6 +135,7 @@ const ReactTestCase = () => {
                   handleChangeItStatementText={handleChangeItStatementText}
                   type="react"
                 />
+                {provided.placeholder}
               </div>
             )}
           </Droppable>

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -28,7 +28,7 @@ const ReactTestCase = () => {
   const { describeBlocks, itStatements, statements } = reactTestCase;
   const [{ mockData }, dispatchToMockData] = useContext(MockDataContext);
   const [{ filePathMap }] = useContext(GlobalContext);
-  const draggableStatements = describeBlocks.allIds;
+  // const draggableStatements = describeBlocks.allIds;
 
   const handleAddMockData = () => {
     dispatchToMockData(createMockData());
@@ -87,7 +87,7 @@ const ReactTestCase = () => {
 
         <DecribeRenderer
           dispatcher={dispatchToReactTestCase}
-          draggableStatements={draggableStatements}
+          // draggableStatements={draggableStatements}
           describeBlocks={describeBlocks}
           itStatements={itStatements}
           statements={statements}

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -31,7 +31,6 @@ const ReactTestCase = () => {
   const { describeBlocks, itStatements, statements } = reactTestCase;
   const [{ mockData }, dispatchToMockData] = useContext(MockDataContext);
   const [{ filePathMap }] = useContext(GlobalContext);
-  // const draggableStatements = describeBlocks.allIds;
 
   const handleAddMockData = () => {
     dispatchToMockData(createMockData());
@@ -130,7 +129,6 @@ const ReactTestCase = () => {
               >
                 <DecribeRenderer
                   dispatcher={dispatchToReactTestCase}
-                  // draggableStatements={draggableStatements}
                   describeBlocks={describeBlocks}
                   itStatements={itStatements}
                   statements={statements}

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -1,10 +1,12 @@
 import React, { useContext, useReducer } from 'react';
 import cn from 'classnames';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import styles from './TestCase.module.scss';
 import {
   updateDescribeText,
   updateRenderComponent,
   updateItStatementText,
+  updateDescribeOrder,
 } from '../../context/actions/reactTestCaseActions';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import SearchInput from '../SearchInput/SearchInput';
@@ -46,6 +48,28 @@ const ReactTestCase = () => {
     dispatchToReactTestCase(updateItStatementText(text, itId));
   };
 
+  const reorder = (list, startIndex, endIndex) => {
+    const result = Array.from(list);
+    const [removed] = result.splice(startIndex, 1);
+    result.splice(endIndex, 0, removed);
+    return result;
+  };
+
+  const onDragEnd = (result) => {
+    if (!result.destination) {
+      return;
+    }
+    if (result.destination.index === result.source.index) {
+      return;
+    }
+    const reorderedStatements = reorder(
+      describeBlocks.allIds,
+      result.source.index,
+      result.destination.index,
+    );
+    dispatchToReactTestCase(updateDescribeOrder(reorderedStatements));
+  };
+
   return (
     <ReactTestCaseContext.Provider value={[reactTestCase, dispatchToReactTestCase]}>
       <div id={styles.ReactTestCase}>
@@ -85,16 +109,27 @@ const ReactTestCase = () => {
           </section>
         )}
 
-        <DecribeRenderer
-          dispatcher={dispatchToReactTestCase}
-          // draggableStatements={draggableStatements}
-          describeBlocks={describeBlocks}
-          itStatements={itStatements}
-          statements={statements}
-          handleChangeDescribeText={handleChangeDescribeText}
-          handleChangeItStatementText={handleChangeItStatementText}
-          type="react"
-        />
+        <DragDropContext onDragEnd={onDragEnd}>
+          <Droppable droppableId="droppable">
+            {(provided) => (
+              <div
+                ref={provided.innerRef}
+                {...provided.droppableProps}
+              >
+                <DecribeRenderer
+                  dispatcher={dispatchToReactTestCase}
+                  // draggableStatements={draggableStatements}
+                  describeBlocks={describeBlocks}
+                  itStatements={itStatements}
+                  statements={statements}
+                  handleChangeDescribeText={handleChangeDescribeText}
+                  handleChangeItStatementText={handleChangeItStatementText}
+                  type="react"
+                />
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
       </div>
     </ReactTestCaseContext.Provider>
   );

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -59,23 +59,16 @@ const ReactTestCase = () => {
     // edge cases: dropped to a non-destination, or dropped where it was grabbed (no change)
     if (!result.destination) return;
     if (result.destination.index === result.source.index) return;
-    console.log(result)
 
-    if (result.draggableId.slice(0, 8) === 'describe') {
-      const reorderedStatements = reorder(
-        describeBlocks.allIds,
-        result.source.index,
-        result.destination.index,
-      );
-      dispatchToReactTestCase(updateDescribeOrder(reorderedStatements));
-    } else if (result.draggableId.slice(0, 2) === 'it') {
-      const reorderedStatements = reorder(
-        itStatements.allIds,
-        result.source.index,
-        result.destination.index,
-      );
-      dispatchToReactTestCase(updateItStatementOrder(reorderedStatements));
-    }
+    const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds;
+    const func = result.draggableId.includes('describe') ? updateDescribeOrder : updateItStatementOrder;
+
+    const reorderedStatements = reorder(
+      list,
+      result.source.index,
+      result.destination.index,
+    );
+    dispatchToReactTestCase(func(reorderedStatements));
   };
 
   return (

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -60,7 +60,7 @@ const ReactTestCase = () => {
     if (!result.destination) return;
     if (result.destination.index === result.source.index) return;
 
-    const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds;
+    const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds[result.type];
     const func = result.draggableId.includes('describe') ? updateDescribeOrder : updateItStatementOrder;
 
     const reorderedStatements = reorder(
@@ -68,7 +68,7 @@ const ReactTestCase = () => {
       result.source.index,
       result.destination.index,
     );
-    dispatchToReactTestCase(func(reorderedStatements));
+    dispatchToReactTestCase(func(reorderedStatements, result.type));
   };
 
   return (

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -119,7 +119,10 @@ const ReactTestCase = () => {
         )}
 
         <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable droppableId="droppableReactDescribe">
+          <Droppable
+            droppableId="droppableReactDescribe"
+            type="describe"
+          >
             {(provided) => (
               <div
                 ref={provided.innerRef}

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -7,6 +7,7 @@ import {
   updateRenderComponent,
   updateItStatementText,
   updateDescribeOrder,
+  updateItStatementOrder,
 } from '../../context/actions/reactTestCaseActions';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import SearchInput from '../SearchInput/SearchInput';
@@ -56,18 +57,26 @@ const ReactTestCase = () => {
   };
 
   const onDragEnd = (result) => {
-    if (!result.destination) {
-      return;
+    // edge cases: dropped to a non-destination, or dropped where it was grabbed (no change)
+    if (!result.destination) return;
+    if (result.destination.index === result.source.index) return;
+    console.log(result)
+
+    if (result.draggableId.slice(0, 8) === 'describe') {
+      const reorderedStatements = reorder(
+        describeBlocks.allIds,
+        result.source.index,
+        result.destination.index,
+      );
+      dispatchToReactTestCase(updateDescribeOrder(reorderedStatements));
+    } else if (result.draggableId.slice(0, 2) === 'it') {
+      const reorderedStatements = reorder(
+        itStatements.allIds,
+        result.source.index,
+        result.destination.index,
+      );
+      dispatchToReactTestCase(updateItStatementOrder(reorderedStatements));
     }
-    if (result.destination.index === result.source.index) {
-      return;
-    }
-    const reorderedStatements = reorder(
-      describeBlocks.allIds,
-      result.source.index,
-      result.destination.index,
-    );
-    dispatchToReactTestCase(updateDescribeOrder(reorderedStatements));
   };
 
   return (

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -20,12 +20,10 @@ import {
 } from '../../context/reducers/reactTestCaseReducer';
 
 const ReactTestCase = () => {
-  //changes to pull down context
   const [reactTestCase, dispatchToReactTestCase] = useReducer(
     reactTestCaseReducer,
-    reactTestCaseState
+    reactTestCaseState,
   );
-  //
 
   const { describeBlocks, itStatements, statements } = reactTestCase;
   const [{ mockData }, dispatchToMockData] = useContext(MockDataContext);
@@ -51,7 +49,7 @@ const ReactTestCase = () => {
   return (
     <ReactTestCaseContext.Provider value={[reactTestCase, dispatchToReactTestCase]}>
       <div id={styles.ReactTestCase}>
-        <div id='head'>
+        <div id="head">
           <ReactTestMenu />
         </div>
 
@@ -66,11 +64,12 @@ const ReactTestCase = () => {
               options={Object.keys(filePathMap)}
             />
           </div>
-          <button type='button' className={styles.mockBtn} onClick={handleAddMockData}>
+          <button type="button" className={styles.mockBtn} onClick={handleAddMockData}>
             <i className={cn(styles.addIcon, 'fas fa-plus')} />
             Mock Data
           </button>
         </div>
+
         {mockData.length > 0 && (
           <section id={styles.mockDataHeader}>
             {mockData.map((data) => {
@@ -85,6 +84,7 @@ const ReactTestCase = () => {
             })}
           </section>
         )}
+
         <DecribeRenderer
           dispatcher={dispatchToReactTestCase}
           draggableStatements={draggableStatements}
@@ -93,10 +93,11 @@ const ReactTestCase = () => {
           statements={statements}
           handleChangeDescribeText={handleChangeDescribeText}
           handleChangeItStatementText={handleChangeItStatementText}
-          type='react'
+          type="react"
         />
       </div>
     </ReactTestCaseContext.Provider>
   );
 };
+
 export default ReactTestCase;

--- a/src/components/TestCase/ReactTestCase.jsx
+++ b/src/components/TestCase/ReactTestCase.jsx
@@ -110,7 +110,7 @@ const ReactTestCase = () => {
         )}
 
         <DragDropContext onDragEnd={onDragEnd}>
-          <Droppable droppableId="droppable">
+          <Droppable droppableId="droppableReactDescribe">
             {(provided) => (
               <div
                 ref={provided.innerRef}

--- a/src/context/actions/reactTestCaseActions.js
+++ b/src/context/actions/reactTestCaseActions.js
@@ -1,15 +1,13 @@
 /* ------------------------------ Action Types ------------------------------ */
 
 export const actionTypes = {
-  TOGGLE_REACT: 'TOGGLE_REACT',
-
   ADD_DESCRIBE_BLOCK: 'ADD_DESCRIBE_BLOCK',
   DELETE_DESCRIBE_BLOCK: 'DELETE_DESCRIBE_BLOCK',
+  UPDATE_DESCRIBE_TEXT: 'UPDATE_DESCRIBE_TEXT',
 
   ADD_ITSTATEMENT: 'ADD_ITSTATEMENT',
-
-  UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
-  UPDATE_DESCRIBE_TEXT: 'UPDATE_DESCRIBE_TEXT',
+  DELETE_ITSTATEMENT: 'DELETE_ITSTATEMENT',
+  UPDATE_ITSTATEMENT_TEXT: 'UPDATE_ITSTATEMENT_TEXT',
 
   ADD_ACTION: 'ADD_ACTION',
   DELETE_ACTION: 'DELETE_ACTION',
@@ -27,12 +25,12 @@ export const actionTypes = {
   DELETE_PROP: 'DELETE_PROP',
   UPDATE_PROP: 'UPDATE_PROP',
 
-  UPDATE_ITSTATEMENT_TEXT: 'UPDATE_ITSTATEMENT_TEXT',
-  DELETE_ITSTATEMENT: 'DELETE_ITSTATEMENT',
-
   CREATE_NEW_TEST: 'CREATE_NEW_TEST',
   OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
+
+  // not used in reducer
+  UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
 };
 
 /* --------------------------------- Actions -------------------------------- */
@@ -50,6 +48,13 @@ export const deleteDescribeBlock = (describeId) => {
   };
 };
 
+export const updateDescribeText = (text, describeId) => ({
+  type: actionTypes.UPDATE_DESCRIBE_TEXT,
+  text,
+  describeId,
+});
+
+
 export const addItstatement = (describeId) => ({
   type: actionTypes.ADD_ITSTATEMENT,
   describeId,
@@ -61,20 +66,12 @@ export const deleteItStatement = (describeId, itId) => ({
   itId,
 });
 
-export const toggleReact = () => ({
-  type: actionTypes.TOGGLE_REACT,
-});
-
-export const updateStatementsOrder = (draggableStatements) => ({
-  type: actionTypes.UPDATE_STATEMENTS_ORDER,
-  draggableStatements,
-});
-
-export const updateDescribeText = (text, describeId) => ({
-  type: actionTypes.UPDATE_DESCRIBE_TEXT,
+export const updateItStatementText = (text, itId) => ({
+  type: actionTypes.UPDATE_ITSTATEMENT_TEXT,
+  itId,
   text,
-  describeId,
 });
+
 
 export const addAction = (describeId, itId) => ({
   type: actionTypes.ADD_ACTION,
@@ -105,6 +102,7 @@ export const updateAction = ({
   queryValue,
   suggestions,
 });
+
 
 export const addAssertion = (describeId, itId) => ({
   type: actionTypes.ADD_ASSERTION,
@@ -138,6 +136,7 @@ export const updateAssertion = ({
   suggestions,
 });
 
+
 export const addRender = (describeId, itId) => ({
   type: actionTypes.ADD_RENDER,
   describeId,
@@ -154,6 +153,7 @@ export const updateRenderComponent = (componentName, filePath) => ({
   componentName,
   filePath,
 });
+
 
 export const addProp = (statementId) => ({
   type: actionTypes.ADD_PROP,
@@ -176,11 +176,6 @@ export const updateProp = (statementId, id, propKey, propValue) => ({
   propValue,
 });
 
-export const updateItStatementText = (text, itId) => ({
-  type: actionTypes.UPDATE_ITSTATEMENT_TEXT,
-  itId,
-  text,
-});
 
 export const createNewTest = () => ({
   type: actionTypes.CREATE_NEW_TEST,
@@ -193,3 +188,12 @@ export const openInfoModal = () => {
 export const closeInfoModal = () => {
   return { type: actionTypes.CLOSE_INFO_MODAL };
 };
+
+
+
+
+// not used in reducer
+export const updateStatementsOrder = (draggableStatements) => ({
+  type: actionTypes.UPDATE_STATEMENTS_ORDER,
+  draggableStatements,
+});

--- a/src/context/actions/reactTestCaseActions.js
+++ b/src/context/actions/reactTestCaseActions.js
@@ -30,9 +30,6 @@ export const actionTypes = {
   CREATE_NEW_TEST: 'CREATE_NEW_TEST',
   OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
-
-  // not used in reducer
-  // UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
 };
 
 /* --------------------------------- Actions -------------------------------- */
@@ -200,12 +197,3 @@ export const openInfoModal = () => {
 export const closeInfoModal = () => {
   return { type: actionTypes.CLOSE_INFO_MODAL };
 };
-
-
-
-
-// not used in reducer
-// export const updateStatementsOrder = (draggableStatements) => ({
-//   type: actionTypes.UPDATE_STATEMENTS_ORDER,
-//   draggableStatements,
-// });

--- a/src/context/actions/reactTestCaseActions.js
+++ b/src/context/actions/reactTestCaseActions.js
@@ -9,6 +9,7 @@ export const actionTypes = {
   ADD_ITSTATEMENT: 'ADD_ITSTATEMENT',
   DELETE_ITSTATEMENT: 'DELETE_ITSTATEMENT',
   UPDATE_ITSTATEMENT_TEXT: 'UPDATE_ITSTATEMENT_TEXT',
+  UPDATE_ITSTATEMENT_ORDER: 'UPDATE_ITSTATEMENT_ORDER',
 
   ADD_ACTION: 'ADD_ACTION',
   DELETE_ACTION: 'DELETE_ACTION',
@@ -76,6 +77,11 @@ export const updateItStatementText = (text, itId) => ({
   type: actionTypes.UPDATE_ITSTATEMENT_TEXT,
   itId,
   text,
+});
+
+export const updateItStatementOrder = (reorderedIt) => ({
+  type: actionTypes.UPDATE_ITSTATEMENT_ORDER,
+  reorderedIt,
 });
 
 

--- a/src/context/actions/reactTestCaseActions.js
+++ b/src/context/actions/reactTestCaseActions.js
@@ -76,9 +76,10 @@ export const updateItStatementText = (text, itId) => ({
   text,
 });
 
-export const updateItStatementOrder = (reorderedIt) => ({
+export const updateItStatementOrder = (reorderedIt, describeId) => ({
   type: actionTypes.UPDATE_ITSTATEMENT_ORDER,
   reorderedIt,
+  describeId,
 });
 
 

--- a/src/context/actions/reactTestCaseActions.js
+++ b/src/context/actions/reactTestCaseActions.js
@@ -30,7 +30,7 @@ export const actionTypes = {
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
 
   // not used in reducer
-  UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
+  // UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
 };
 
 /* --------------------------------- Actions -------------------------------- */
@@ -193,7 +193,7 @@ export const closeInfoModal = () => {
 
 
 // not used in reducer
-export const updateStatementsOrder = (draggableStatements) => ({
-  type: actionTypes.UPDATE_STATEMENTS_ORDER,
-  draggableStatements,
-});
+// export const updateStatementsOrder = (draggableStatements) => ({
+//   type: actionTypes.UPDATE_STATEMENTS_ORDER,
+//   draggableStatements,
+// });

--- a/src/context/actions/reactTestCaseActions.js
+++ b/src/context/actions/reactTestCaseActions.js
@@ -4,6 +4,7 @@ export const actionTypes = {
   ADD_DESCRIBE_BLOCK: 'ADD_DESCRIBE_BLOCK',
   DELETE_DESCRIBE_BLOCK: 'DELETE_DESCRIBE_BLOCK',
   UPDATE_DESCRIBE_TEXT: 'UPDATE_DESCRIBE_TEXT',
+  UPDATE_DESCRIBE_ORDER: 'UPDATE_DESCRIBE_ORDER',
 
   ADD_ITSTATEMENT: 'ADD_ITSTATEMENT',
   DELETE_ITSTATEMENT: 'DELETE_ITSTATEMENT',
@@ -52,6 +53,11 @@ export const updateDescribeText = (text, describeId) => ({
   type: actionTypes.UPDATE_DESCRIBE_TEXT,
   text,
   describeId,
+});
+
+export const updateDescribeOrder = (reorderedDescribe) => ({
+  type: actionTypes.UPDATE_DESCRIBE_ORDER,
+  reorderedDescribe,
 });
 
 

--- a/src/context/reducers/reactTestCaseReducer.js
+++ b/src/context/reducers/reactTestCaseReducer.js
@@ -147,24 +147,6 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
-    case actionTypes.UPDATE_DESCRIBE_TEXT: {
-      const { describeId, text } = action;
-      const byIds = { ...describeBlocks.byId };
-      const block = { ...describeBlocks.byId[describeId] };
-      return {
-        ...state,
-        describeBlocks: {
-          ...describeBlocks,
-          byId: {
-            ...byIds,
-            [describeId]: {
-              ...block,
-              text,
-            },
-          },
-        },
-      };
-    }
     case actionTypes.DELETE_DESCRIBE_BLOCK: {
       const { describeId } = action;
       const byId = { ...describeBlocks.byId };
@@ -196,6 +178,24 @@ export const reactTestCaseReducer = (state, action) => {
             ...statements.byId,
           },
           allIds: [...statementAllIds],
+        },
+      };
+    }
+    case actionTypes.UPDATE_DESCRIBE_TEXT: {
+      const { describeId, text } = action;
+      const byIds = { ...describeBlocks.byId };
+      const block = { ...describeBlocks.byId[describeId] };
+      return {
+        ...state,
+        describeBlocks: {
+          ...describeBlocks,
+          byId: {
+            ...byIds,
+            [describeId]: {
+              ...block,
+              text,
+            },
+          },
         },
       };
     }
@@ -261,6 +261,7 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
+
     case actionTypes.ADD_ACTION: {
       const { describeId, itId } = action;
       const byIds = { ...statements.byId };
@@ -278,6 +279,22 @@ export const reactTestCaseReducer = (state, action) => {
             [statementId]: createAction(describeId, itId, statementId),
           },
           allIds: [...allIds, statementId],
+        },
+      };
+    }
+    case actionTypes.DELETE_ACTION: {
+      const { statementId } = action;
+      const byId = { ...statements.byId };
+      delete byId[statementId];
+      const allIds = [...statements.allIds].filter((statement) => statement !== statementId);
+      return {
+        ...state,
+        statements: {
+          ...statements,
+          byId: {
+            ...byId,
+          },
+          allIds: [...allIds],
         },
       };
     }
@@ -315,22 +332,7 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
-    case actionTypes.DELETE_ACTION: {
-      const { statementId } = action;
-      const byId = { ...statements.byId };
-      delete byId[statementId];
-      const allIds = [...statements.allIds].filter((statement) => statement !== statementId);
-      return {
-        ...state,
-        statements: {
-          ...statements,
-          byId: {
-            ...byId,
-          },
-          allIds: [...allIds],
-        },
-      };
-    }
+
     case actionTypes.ADD_ASSERTION: {
       const { describeId, itId } = action;
       const byIds = { ...statements.byId };
@@ -348,6 +350,22 @@ export const reactTestCaseReducer = (state, action) => {
             [statementId]: createAssertion(describeId, itId, statementId),
           },
           allIds: [...allIds, statementId],
+        },
+      };
+    }
+    case actionTypes.DELETE_ASSERTION: {
+      const { statementId } = action;
+      const byId = { ...statements.byId };
+      delete byId[statementId];
+      const allIds = [...statements.allIds].filter((statement) => statement !== statementId);
+      return {
+        ...state,
+        statements: {
+          ...statements,
+          byId: {
+            ...byId,
+          },
+          allIds: [...allIds],
         },
       };
     }
@@ -387,22 +405,7 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
-    case actionTypes.DELETE_ASSERTION: {
-      const { statementId } = action;
-      const byId = { ...statements.byId };
-      delete byId[statementId];
-      const allIds = [...statements.allIds].filter((statement) => statement !== statementId);
-      return {
-        ...state,
-        statements: {
-          ...statements,
-          byId: {
-            ...byId,
-          },
-          allIds: [...allIds],
-        },
-      };
-    }
+
     case actionTypes.ADD_RENDER: {
       const { describeId, itId } = action;
       const byIds = { ...statements.byId };
@@ -423,15 +426,6 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
-    case actionTypes.UPDATE_RENDER_COMPONENT: {
-      const { componentName, filePath } = action;
-      statements.componentName = componentName;
-      statements.componentPath = filePath;
-      return {
-        ...state,
-        statements,
-      };
-    }
     case actionTypes.DELETE_RENDER: {
       const { statementId } = action;
       const byId = { ...statements.byId };
@@ -448,6 +442,16 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
+    case actionTypes.UPDATE_RENDER_COMPONENT: {
+      const { componentName, filePath } = action;
+      statements.componentName = componentName;
+      statements.componentPath = filePath;
+      return {
+        ...state,
+        statements,
+      };
+    }
+
     case actionTypes.ADD_PROP: {
       const { statementId } = action;
       const propId = `prop${state.propId}`;
@@ -464,6 +468,23 @@ export const reactTestCaseReducer = (state, action) => {
             [statementId]: {
               ...statements.byId[statementId],
               props: [...statements.byId[statementId].props, createProp(propId, statementId)],
+            },
+          },
+        },
+      };
+    }
+    case actionTypes.DELETE_PROP: {
+      const { id, statementId } = action;
+      const props = statements.byId[statementId].props.filter((prop) => prop.id !== id);
+      return {
+        ...state,
+        statements: {
+          ...statements,
+          byId: {
+            ...statements.byId,
+            [statementId]: {
+              ...statements.byId[statementId],
+              props,
             },
           },
         },
@@ -494,23 +515,7 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
-    case actionTypes.DELETE_PROP: {
-      const { id, statementId } = action;
-      const props = statements.byId[statementId].props.filter((prop) => prop.id !== id);
-      return {
-        ...state,
-        statements: {
-          ...statements,
-          byId: {
-            ...statements.byId,
-            [statementId]: {
-              ...statements.byId[statementId],
-              props,
-            },
-          },
-        },
-      };
-    }
+
     case actionTypes.CREATE_NEW_TEST: {
       return {
         ...state,
@@ -528,16 +533,18 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
-    case actionTypes.OPEN_INFO_MODAL:
+    case actionTypes.OPEN_INFO_MODAL: {
       return {
         ...state,
         modalOpen: true,
       };
-    case actionTypes.CLOSE_INFO_MODAL:
+    }
+    case actionTypes.CLOSE_INFO_MODAL: {
       return {
         ...state,
         modalOpen: false,
       };
+    }
     default:
       return state;
   }

--- a/src/context/reducers/reactTestCaseReducer.js
+++ b/src/context/reducers/reactTestCaseReducer.js
@@ -271,6 +271,16 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
+    case actionTypes.UPDATE_ITSTATEMENT_ORDER: {
+      const { reorderedIt } = action;
+      return {
+        ...state,
+        itStatements: {
+          ...itStatements,
+          allIds: reorderedIt,
+        },
+      };
+    }
 
     case actionTypes.ADD_ACTION: {
       const { describeId, itId } = action;

--- a/src/context/reducers/reactTestCaseReducer.js
+++ b/src/context/reducers/reactTestCaseReducer.js
@@ -199,6 +199,16 @@ export const reactTestCaseReducer = (state, action) => {
         },
       };
     }
+    case actionTypes.UPDATE_DESCRIBE_ORDER: {
+      const { reorderedDescribe } = action;
+      return {
+        ...state,
+        describeBlocks: {
+          ...describeBlocks,
+          allIds: reorderedDescribe,
+        },
+      };
+    }
 
     case actionTypes.ADD_ITSTATEMENT: {
       const { describeId } = action;

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -39,13 +39,10 @@ function useGenerateTest(test, projectFilePath) {
     // React It Statements
     const addReactItStatement = (describeId) => {
       const itStatements = reactTestCase.itStatements;
-      itStatements.allIds.forEach((itId) => {
-        if (itStatements.byId[itId].describeId === describeId) {
-          testFileCode += `it('${itStatements.byId[itId].text}', () => {`;
-          addReactStatements(itId);
-          testFileCode += '})';
-        }
-        testFileCode += '\n';
+      itStatements.allIds[describeId].forEach((itId) => {
+        testFileCode += `it('${itStatements.byId[itId].text}', () => {`;
+        addReactStatements(itId);
+        testFileCode += '})\n';
       });
     };
 


### PR DESCRIPTION
# Implement Drag and Drop (DnD) in React Test Case
### Summary of Changes

Good evening, team!

The `ReactTestCase` component (panel between the file tree and code preview) as well as its child components (such as DescribeRenderer, ItRenderer) were revamped with drag and drop functionality! Users can now drag describe blocks to reorder them, as well as drag it statements within each describe block to reorder them. The new feature is "smart" as in it detects and rejects if you drop a component where it doesn't belong. Plus, the tool we use,  [react-beautiful-dnd](https://www.npmjs.com/package/react-beautiful-dnd), comes with built-in [accessibility functionality](https://github.com/atlassian/react-beautiful-dnd/blob/master/docs/about/accessibility.md) - no extra setup needed!

One significant yet less-visible change had to be made in order to make this possible. I refactored the `ReactTestCaseContext` "itStatements" property's "allIds" property to be an object (compared to previously an array), in order to make the logic of reordering it statements with DnD make sense.

<div align="center">
<img margin="auto" src="https://user-images.githubusercontent.com/73931127/111590507-6a5edf00-8783-11eb-8b2a-5289b63c65d4.gif">
</img>
<br>
<caption>[Alt Text: GIF demo-ing the new drag and drop feature in Spearmint's react test generation page. First, the user demos a describe block being DnD. Then, the user demos it statements being DnD within a describe block. Lastly, the user demos the way that the DnD feature does not allow drops outside of the draggable component's original scope.]</caption>
</div>

<hr>

### Code Review

This PR alters 6 files:

```
| src/components
  | /ReactTestComponent
    | /DescribeRenderer/DescribeRenderer.jsx 
    | /ItRenderer/ItRenderer.jsx
  | /TestCase/ReactTestCase.jsx
| src/context/
  | /useGenerateTest.jsx
  | /reducers/reactTestCaseReducer.js
  | /actions/reactTestCaseActions.js
```
`DescribeRenderer.jsx` `ItRenderer.jsx` `ReactTestCase.jsx`
- Removed past groups' attempt at implementing DnD functionality.
- Wrap components in DragDropContext, Droppable, and Draggable components from react-beautiful-dnd as appropriate.
  - Note: Along with these components came a lot of specific configuration, as per the [docs](https://github.com/atlassian/react-beautiful-dnd/tree/master/docs/api).

`reactTestCaseReducer.js` `reactTestCaseActions.js`
- Reordered actions, action creators, and switch cases in order to match each other and be intuitive.
- Added UPDATE_DESCRIBE_ORDER and UPDATE_ITSTATEMENT_ORDER functionality.
- On the reducer file, quite a lot of changes needed to be made to accommodate the change to `ReactTestCaseContext`. Please refer to [this](https://github.com/oslabs-beta/spearmint/commit/050fb9ac1eeb9333b462544c0f38c701d119c518) commit for a better side-by-side comparison of changes regarding the specific change in context/state.

`useGenerateTest.jsx`
- Minor change was made as a result of changing `ReactTestCaseContext`.