### PR TITLE
Adding Drag and Drop Functionality to the Accessibility Portion of Spearmint

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,10 +8,6 @@ import RightPanel from './pages/RightPanel/RightPanel';
 import About from './pages/About/About';
 
 const App = () => {
-  // useReducer takes a reducer and initial state as
-  // args and return the current state paired with a dispatch method
-  // distpatchTo method invokes associated reducer function
-
   const [global, dispatchToGlobal] = useReducer(globalReducer, globalState);
 
   if (!global.isProjectLoaded) {

--- a/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
+++ b/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
@@ -1,11 +1,10 @@
 // import React object and destructure useRef and useEffect hooks
 import React, { useRef, useEffect } from 'react';
 import cn from 'classnames';
-import { Draggable } from 'react-beautiful-dnd';
+import { Draggable, Droppable } from 'react-beautiful-dnd';
 
 // import It component
 import ItRenderer from '../ItRenderer/ItRenderer';
-
 
 // import styling
 import styles from './DescribeRenderer.module.scss';
@@ -66,6 +65,7 @@ const DescribeRenderer = ({
             <label htmlFor="describe-label" className={styles.describeLabel}>
               Describe Block
             </label>
+            {id}
 
             <i
               onClick={deleteDescribeBlockHandleClick}
@@ -85,14 +85,28 @@ const DescribeRenderer = ({
             />
 
             <div className={styles.separator} />
-            <ItRenderer
-              type={type}
-              key={`it-${id}-${i}`}
-              itStatements={itStatements}
-              statements={statements}
-              describeId={id}
-              handleChangeItStatementText={handleChangeItStatementText}
-            />
+
+            <Droppable
+              droppableId={"droppableAccIt" + id}
+              type={id}
+            >
+              {(innerProvided) => (
+                <div
+                  ref={innerProvided.innerRef}
+                  {...innerProvided.droppableProps}
+                >
+                  <ItRenderer
+                    type={type}
+                    key={`it-${id}-${i}`}
+                    itStatements={itStatements}
+                    statements={statements}
+                    describeId={id}
+                    handleChangeItStatementText={handleChangeItStatementText}
+                  />
+                  {innerProvided.placeholder}
+                </div>
+              )}
+            </Droppable>
 
             {/* Implement Button For Stretch */}
             <div className={styles.buttonContainer}>
@@ -102,17 +116,9 @@ const DescribeRenderer = ({
             </div>
 
           </div>
-
-
-
         </div>
       )}
     </Draggable>
-
-
-
-
-
   ));
 };
 

--- a/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
+++ b/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
@@ -1,24 +1,9 @@
-// import React object and destructure useRef and useEffect hooks
 import React, { useRef, useEffect } from 'react';
 import cn from 'classnames';
 import { Draggable, Droppable } from 'react-beautiful-dnd';
-
-// import It component
 import ItRenderer from '../ItRenderer/ItRenderer';
-
-// import styling
 import styles from './DescribeRenderer.module.scss';
-
-// import action types
 import { deleteDescribeBlock, addItStatement } from '../../../context/actions/accTestCaseActions';
-
-// import from accTypes - ### add after html structure is created?
-// import { Assertion, AccObj, Header, Action, EventTarget } from '../../utils/accTypes';
-
-// require in icons
-// const closeIcon = require('../../../assets/images/close.png');
-// const dragIcon = require('../../assets/images/drag-vertical.png');
-// const minusIcon = require('../../assets/images/minus-box-outline.png');
 
 const DescribeRenderer = ({
   dispatcher,
@@ -62,7 +47,6 @@ const DescribeRenderer = ({
             <label htmlFor="describe-label" className={styles.describeLabel}>
               Describe Block
             </label>
-            {id}
 
             <i
               onClick={deleteDescribeBlockHandleClick}
@@ -104,7 +88,6 @@ const DescribeRenderer = ({
               )}
             </Droppable>
 
-            {/* Implement Button For Stretch */}
             <div className={styles.buttonContainer}>
               <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>
                 +It Statement

--- a/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
+++ b/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
@@ -1,30 +1,25 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable linebreak-style */
-/* eslint-disable no-trailing-spaces */
-// import React object and destructure useRef and useEffect hooks 
+// import React object and destructure useRef and useEffect hooks
 import React, { useRef, useEffect } from 'react';
+import cn from 'classnames';
+// import { Draggable } from 'react-beautiful-dnd';
 
 // import It component
 import ItRenderer from '../ItRenderer/ItRenderer';
 
-// import Draggable for drag and drop functionality
-import { Draggable } from 'react-beautiful-dnd';
 
-// import styling 
+// import styling
 import styles from './DescribeRenderer.module.scss';
 
-// import action types 
+// import action types
 import { deleteDescribeBlock, addItStatement } from '../../../context/actions/accTestCaseActions';
 
-// import from accTypes - ### add after html structure is created? 
-import { Assertion, AccObj, Header, Action, EventTarget } from '../../utils/accTypes';
+// import from accTypes - ### add after html structure is created?
+// import { Assertion, AccObj, Header, Action, EventTarget } from '../../utils/accTypes';
 
-import cn from 'classnames';
 // require in icons
-const closeIcon = require('../../../assets/images/close.png');
+// const closeIcon = require('../../../assets/images/close.png');
 // const dragIcon = require('../../assets/images/drag-vertical.png');
 // const minusIcon = require('../../assets/images/minus-box-outline.png');
-
 
 const DescribeRenderer = ({
   dispatcher,
@@ -56,7 +51,7 @@ const DescribeRenderer = ({
   return draggableStatements.map((id, i) => {
     return (
       <div id={styles.describeBlock} key={i}>
-        <label htmlFor='describe-label' className={styles.describeLabel}>
+        <label htmlFor="describe-label" className={styles.describeLabel}>
           Describe Block
         </label>
 
@@ -64,20 +59,20 @@ const DescribeRenderer = ({
           onClick={deleteDescribeBlockHandleClick}
           id={id}
           className={cn('far fa-window-close', styles.describeClose)}
-        ></i>
+         />
 
         <input
           ref={testDescription}
           id={id}
           className={styles.describeInput}
-          name='describe-label'
-          type='text'
-          placeholder={'Component has basic accessibility'}
+          name="describe-label"
+          type="text"
+          placeholder="Component has basic accessibility"
           value={describeBlocks.byId[id].text || ''}
           onChange={handleChangeDescribeText}
         />
 
-        <div className={styles.separator}></div>
+        <div className={styles.separator} />
         <ItRenderer
           type={type}
           key={`it-${id}-${i}`}
@@ -100,5 +95,3 @@ const DescribeRenderer = ({
 };
 
 export default DescribeRenderer;
-
-  

--- a/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
+++ b/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
@@ -1,7 +1,7 @@
 // import React object and destructure useRef and useEffect hooks
 import React, { useRef, useEffect } from 'react';
 import cn from 'classnames';
-// import { Draggable } from 'react-beautiful-dnd';
+import { Draggable } from 'react-beautiful-dnd';
 
 // import It component
 import ItRenderer from '../ItRenderer/ItRenderer';
@@ -49,46 +49,70 @@ const DescribeRenderer = ({
   };
 
   return draggableStatements.map((id, i) => (
-      <div id={styles.describeBlock} key={i}>
-        <label htmlFor="describe-label" className={styles.describeLabel}>
-          Describe Block
-        </label>
+    <Draggable
+      key={id}
+      draggableId={id}
+      index={i}
+      type="describe"
+    >
+      {(provided) => (
+        <div
+          id={styles.describeBlock}
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+        >
+          <div id={styles.describeBlock} key={i}>
+            <label htmlFor="describe-label" className={styles.describeLabel}>
+              Describe Block
+            </label>
 
-        <i
-          onClick={deleteDescribeBlockHandleClick}
-          id={id}
-          className={cn('far fa-window-close', styles.describeClose)}
-         />
+            <i
+              onClick={deleteDescribeBlockHandleClick}
+              id={id}
+              className={cn('far fa-window-close', styles.describeClose)}
+            />
 
-        <input
-          ref={testDescription}
-          id={id}
-          className={styles.describeInput}
-          name="describe-label"
-          type="text"
-          placeholder="Component has basic accessibility"
-          value={describeBlocks.byId[id].text || ''}
-          onChange={handleChangeDescribeText}
-        />
+            <input
+              ref={testDescription}
+              id={id}
+              className={styles.describeInput}
+              name="describe-label"
+              type="text"
+              placeholder="Component has basic accessibility"
+              value={describeBlocks.byId[id].text || ''}
+              onChange={handleChangeDescribeText}
+            />
 
-        <div className={styles.separator} />
-        <ItRenderer
-          type={type}
-          key={`it-${id}-${i}`}
-          itStatements={itStatements}
-          statements={statements}
-          describeId={id}
-          handleChangeItStatementText={handleChangeItStatementText}
-        />
+            <div className={styles.separator} />
+            <ItRenderer
+              type={type}
+              key={`it-${id}-${i}`}
+              itStatements={itStatements}
+              statements={statements}
+              describeId={id}
+              handleChangeItStatementText={handleChangeItStatementText}
+            />
 
-        {/* Implement Button For Stretch */}
-        <div className={styles.buttonContainer}>
-          <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>
-            +It Statement
-          </button>
+            {/* Implement Button For Stretch */}
+            <div className={styles.buttonContainer}>
+              <button className={styles.addIt} id={id} onClick={addItStatementHandleClick}>
+                +It Statement
+              </button>
+            </div>
+
+          </div>
+
+
+
         </div>
+      )}
+    </Draggable>
 
-      </div>
+
+
+
+
   ));
 };
 

--- a/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
+++ b/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
@@ -56,7 +56,6 @@ const DescribeRenderer = ({
     >
       {(provided) => (
         <div
-          id={styles.describeBlock}
           ref={provided.innerRef}
           {...provided.draggableProps}
           {...provided.dragHandleProps}

--- a/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
+++ b/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
@@ -48,8 +48,7 @@ const DescribeRenderer = ({
     dispatcher(addItStatement(describeId));
   };
 
-  return draggableStatements.map((id, i) => {
-    return (
+  return draggableStatements.map((id, i) => (
       <div id={styles.describeBlock} key={i}>
         <label htmlFor="describe-label" className={styles.describeLabel}>
           Describe Block
@@ -90,8 +89,7 @@ const DescribeRenderer = ({
         </div>
 
       </div>
-    );
-  });
+  ));
 };
 
 export default DescribeRenderer;

--- a/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
+++ b/src/components/AccTestComponent/DescribeRenderer/DescribeRenderer.tsx
@@ -24,8 +24,6 @@ const DescribeRenderer = ({
   dispatcher,
   describeBlocks,
   itStatements,
-  statements,
-  draggableStatements,
   handleChangeDescribeText,
   handleChangeItStatementText,
   type,
@@ -47,7 +45,7 @@ const DescribeRenderer = ({
     dispatcher(addItStatement(describeId));
   };
 
-  return draggableStatements.map((id, i) => (
+  return describeBlocks.allIds.map((id, i) => (
     <Draggable
       key={id}
       draggableId={id}
@@ -98,7 +96,6 @@ const DescribeRenderer = ({
                     type={type}
                     key={`it-${id}-${i}`}
                     itStatements={itStatements}
-                    statements={statements}
                     describeId={id}
                     handleChangeItStatementText={handleChangeItStatementText}
                   />

--- a/src/components/AccTestComponent/ItRenderer/ItRenderer.tsx
+++ b/src/components/AccTestComponent/ItRenderer/ItRenderer.tsx
@@ -1,11 +1,7 @@
 import React, { useContext } from 'react';
 import cn from 'classnames';
 import { Draggable } from 'react-beautiful-dnd';
-
 import { AccTestCaseContext } from '../../../context/reducers/accTestCaseReducer';
-
-// test case statements are for action, assertion, and render options
-// import AccTestStatements from '../../TestCase/AccTestStatements';
 
 import {
   deleteItStatement,
@@ -24,20 +20,14 @@ const ItRenderer = ({
 
   const [, dispatchToAccTestCase] = useContext(AccTestCaseContext);
 
-  // filter out ids not belonging to the correct describe block
-  // ### do we need this?
-  const filteredIds = itStatements.allIds.filter((id) => {
-    return itStatements.byId[id].describeId === describeId;
-  });
-
   const deleteItStatementHandleClick = (e) => {
     const itId = e.target.id;
     dispatchToAccTestCase(deleteItStatement(describeId, itId));
   };
 
-  return filteredIds.map((id, i) => (
+  return itStatements.allIds[describeId].map((id, i) => (
     <Draggable
-      draggableId={describeId + id}
+      draggableId={id}
       index={i}
     >
       {(provided) => (
@@ -72,12 +62,3 @@ const ItRenderer = ({
 };
 
 export default ItRenderer;
-
-
-// ## stretch use?
-// <ReactTestStatements
-//   key={`statement-${id}-${i}`}
-//   statements={statements}
-//   itId={id}
-//   describeId={describeId}
-// /> 

--- a/src/components/AccTestComponent/ItRenderer/ItRenderer.tsx
+++ b/src/components/AccTestComponent/ItRenderer/ItRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from 'react';
 import cn from 'classnames';
+import { Draggable } from 'react-beautiful-dnd';
 
 import { AccTestCaseContext } from '../../../context/reducers/accTestCaseReducer';
 
@@ -30,33 +31,44 @@ const ItRenderer = ({
     return itStatements.byId[id].describeId === describeId;
   });
 
-
   const deleteItStatementHandleClick = (e) => {
     const itId = e.target.id;
     dispatchToAccTestCase(deleteItStatement(describeId, itId));
   };
 
   return filteredIds.map((id, i) => (
-    <div id={styles.ItRenderer} key={i}>
+    <Draggable
+      draggableId={describeId + id}
+      index={i}
+    >
+      {(provided) => (
+        <div
+          ref={provided.innerRef}
+          {...provided.draggableProps}
+          {...provided.dragHandleProps}
+          id={styles.ItRenderer}
+          key={i}
+        >
 
-      <i
-        onClick={deleteItStatementHandleClick}
-        id={id}
-        className={cn(styles.itClose, 'far fa-window-close')}
-      ></i>
+          <i
+            onClick={deleteItStatementHandleClick}
+            id={id}
+            className={cn(styles.itClose, 'far fa-window-close')}
+          />
 
-      <CustomInput
-        key={`input-${id}-${i}`}
-        id={id}
-        label={'The element should...'}
-        placeholder={'The tested element should...'}
-        value={itStatements.byId[id].text}
-        handleChange={handleChangeItStatementText}
-      />
+          <CustomInput
+            key={`input-${id}-${i}`}
+            id={id}
+            label={'The element should...'}
+            placeholder={'The tested element should...'}
+            value={itStatements.byId[id].text}
+            handleChange={handleChangeItStatementText}
+          />
+          <hr />
 
-      <hr />
- 
-    </div>
+        </div>
+      )}
+    </Draggable>
   ));
 };
 

--- a/src/components/AccTestComponent/ItRenderer/ItRenderer.tsx
+++ b/src/components/AccTestComponent/ItRenderer/ItRenderer.tsx
@@ -19,7 +19,6 @@ const ItRenderer = ({
   type,
   itStatements,
   describeId,
-  statements,
   handleChangeItStatementText,
 }) => {
 

--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -33,8 +33,7 @@ const DescribeRenderer = ({
     dispatcher(addItstatement(describeId));
   };
 
-  return describeBlocks.allIds.map((id, i) => {
-    return (
+  return describeBlocks.allIds.map((id, i) => (
       <Draggable
         key={id}
         draggableId={id}
@@ -100,8 +99,7 @@ const DescribeRenderer = ({
 
         )}
       </Draggable>
-    );
-  });
+  ));
 };
 
 export default DescribeRenderer;

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -27,10 +27,9 @@ const AccTestCase = () => {
     AccTestCaseContext,
   );
 
-  const { describeBlocks, itStatements, statements } = accTestCase;
+  const { describeBlocks, itStatements } = accTestCase;
 
   const [{ filePathMap }] = useContext(GlobalContext);
-  const draggableStatements = describeBlocks.allIds;
 
   const handleChangeDescribeText = (e) => {
     const text = e.target.value;
@@ -99,10 +98,8 @@ const AccTestCase = () => {
               >
                 <DecribeRenderer
                   dispatcher={dispatchToAccTestCase}
-                  draggableStatements={draggableStatements}
                   describeBlocks={describeBlocks}
                   itStatements={itStatements}
-                  statements={statements}
                   handleChangeDescribeText={handleChangeDescribeText}
                   handleChangeItStatementText={handleChangeItStatementText}
                   type="acc"

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -11,7 +11,6 @@ import {
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import SearchInput from '../SearchInput/SearchInput';
 
-// ### this ties in with Sharon's code - did not create a file ### VERIFY PATH
 import AccTestMenu from '../TestMenu/AccTestMenu';
 
 import DecribeRenderer from '../AccTestComponent/DescribeRenderer/DescribeRenderer';
@@ -51,27 +50,22 @@ const AccTestCase = () => {
   };
 
   const onDragEnd = (result) => {
-    console.log(result);
     // edge cases: dropped to a non-destination, or dropped where it was grabbed (no change)
     if (!result.destination) return;
     if (result.destination.index === result.source.index) return;
 
-    const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds;
+    const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds[result.type];
     const func = result.draggableId.includes('describe') ? updateDescribeOrder : updateItStatementOrder;
 
-    const reorderedStatements = reorder(
-      list,
-      result.source.index,
-      result.destination.index,
-    );
-    dispatchToAccTestCase(func(reorderedStatements));
+    const reorderedStatements = reorder(list, result.source.index, result.destination.index);
+
+    dispatchToAccTestCase(func(reorderedStatements, result.type));
   };
 
   return (
     <div id={styles.AccTestCase}>
 
       <div id="head">
-        {JSON.stringify(accTestCase)}
         <AccTestMenu />
       </div>
 

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -1,9 +1,11 @@
 import React, { useContext, useReducer } from 'react';
 import cn from 'classnames';
+import { DragDropContext, Droppable } from 'react-beautiful-dnd';
 import styles from './TestCase.module.scss';
 import {
   updateDescribeText,
   updateItStatementText,
+  updateDescribeOrder,
 } from '../../context/actions/accTestCaseActions';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import SearchInput from '../SearchInput/SearchInput';
@@ -41,6 +43,29 @@ const AccTestCase = () => {
     dispatchToAccTestCase(updateItStatementText(text, itId));
   };
 
+  const reorder = (list, startIndex, endIndex) => {
+    const result = Array.from(list);
+    const [removed] = result.splice(startIndex, 1);
+    result.splice(endIndex, 0, removed);
+    return result;
+  };
+
+  const onDragEnd = (result) => {
+    // edge cases: dropped to a non-destination, or dropped where it was grabbed (no change)
+    if (!result.destination) return;
+    if (result.destination.index === result.source.index) return;
+
+    // const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds[result.type];
+    // const func = result.draggableId.includes('describe') ? updateDescribeOrder : updateItStatementOrder;
+
+    const reorderedStatements = reorder(
+      describeBlocks.allIds,
+      result.source.index,
+      result.destination.index,
+    );
+    dispatchToAccTestCase(updateDescribeOrder(reorderedStatements));
+  };
+
   return (
     <div id={styles.AccTestCase}>
 
@@ -59,16 +84,30 @@ const AccTestCase = () => {
           />
         </div>
 
-        <DecribeRenderer
-          dispatcher={dispatchToAccTestCase}
-          draggableStatements={draggableStatements}
-          describeBlocks={describeBlocks}
-          itStatements={itStatements}
-          statements={statements}
-          handleChangeDescribeText={handleChangeDescribeText}
-          handleChangeItStatementText={handleChangeItStatementText}
-          type="acc"
-        />
+        <DragDropContext onDragEnd={onDragEnd}>
+          <Droppable
+            droppableId="droppableAccDescribe"
+            type="describe"
+          >
+            {(provided) => (
+              <div
+              ref={provided.innerRef}
+              {...provided.droppableProps}
+              >
+                <DecribeRenderer
+                  dispatcher={dispatchToAccTestCase}
+                  draggableStatements={draggableStatements}
+                  describeBlocks={describeBlocks}
+                  itStatements={itStatements}
+                  statements={statements}
+                  handleChangeDescribeText={handleChangeDescribeText}
+                  handleChangeItStatementText={handleChangeItStatementText}
+                  type="acc"
+                />
+              </div>
+            )}
+          </Droppable>
+        </DragDropContext>
       </section>
 
     </div>

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -6,6 +6,7 @@ import {
   updateDescribeText,
   updateItStatementText,
   updateDescribeOrder,
+  updateItStatementOrder,
 } from '../../context/actions/accTestCaseActions';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import SearchInput from '../SearchInput/SearchInput';
@@ -51,25 +52,27 @@ const AccTestCase = () => {
   };
 
   const onDragEnd = (result) => {
+    console.log(result);
     // edge cases: dropped to a non-destination, or dropped where it was grabbed (no change)
     if (!result.destination) return;
     if (result.destination.index === result.source.index) return;
 
-    // const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds[result.type];
-    // const func = result.draggableId.includes('describe') ? updateDescribeOrder : updateItStatementOrder;
+    const list = result.draggableId.includes('describe') ? describeBlocks.allIds : itStatements.allIds;
+    const func = result.draggableId.includes('describe') ? updateDescribeOrder : updateItStatementOrder;
 
     const reorderedStatements = reorder(
-      describeBlocks.allIds,
+      list,
       result.source.index,
       result.destination.index,
     );
-    dispatchToAccTestCase(updateDescribeOrder(reorderedStatements));
+    dispatchToAccTestCase(func(reorderedStatements));
   };
 
   return (
     <div id={styles.AccTestCase}>
 
       <div id="head">
+        {JSON.stringify(accTestCase)}
         <AccTestMenu />
       </div>
 
@@ -104,6 +107,7 @@ const AccTestCase = () => {
                   handleChangeItStatementText={handleChangeItStatementText}
                   type="acc"
                 />
+                {provided.placeholder}
               </div>
             )}
           </Droppable>

--- a/src/context/actions/accTestCaseActions.js
+++ b/src/context/actions/accTestCaseActions.js
@@ -19,7 +19,6 @@ export const actionTypes = {
 
   // not yet implemented:
   TOGGLE_ACC: 'TOGGLE_ACC',
-  UPDATE_STATEMENTS_ORDER: 'UPDATE_STATEMENTS_ORDER',
 };
 
 /* --------------------------------- Actions -------------------------------- */
@@ -95,9 +94,4 @@ export const updateImportFilePath = (fileName, filePath) => ({
 // the below have no corresponding functions in Reducer
 export const toggleAcc = () => ({
   type: actionTypes.TOGGLE_ACC,
-});
-
-export const updateStatementsOrder = (draggableStatements) => ({
-  type: actionTypes.UPDATE_STATEMENTS_ORDER,
-  draggableStatements,
 });

--- a/src/context/actions/accTestCaseActions.js
+++ b/src/context/actions/accTestCaseActions.js
@@ -4,6 +4,7 @@ export const actionTypes = {
   ADD_DESCRIBE_BLOCK: 'ADD_DESCRIBE_BLOCK',
   DELETE_DESCRIBE_BLOCK: 'DELETE_DESCRIBE_BLOCK',
   UPDATE_DESCRIBE_TEXT: 'UPDATE_DESCRIBE_TEXT',
+  UPDATE_DESCRIBE_ORDER: 'UPDATE_DESCRIBE_ORDER',
 
   ADD_ITSTATEMENT: 'ADD_ITSTATEMENT',
   DELETE_ITSTATEMENT: 'DELETE_ITSTATEMENT',
@@ -40,6 +41,13 @@ export const updateDescribeText = (text, describeId) => ({
   text,
   describeId,
 });
+
+export const updateDescribeOrder = (reorderedDescribe) => {
+  return {
+    type: actionTypes.UPDATE_DESCRIBE_ORDER,
+    reorderedDescribe,
+  };
+};
 
 export const addItStatement = (describeId) => ({
   type: actionTypes.ADD_ITSTATEMENT,

--- a/src/context/actions/accTestCaseActions.js
+++ b/src/context/actions/accTestCaseActions.js
@@ -9,6 +9,7 @@ export const actionTypes = {
   ADD_ITSTATEMENT: 'ADD_ITSTATEMENT',
   DELETE_ITSTATEMENT: 'DELETE_ITSTATEMENT',
   UPDATE_ITSTATEMENT_TEXT: 'UPDATE_ITSTATEMENT_TEXT',
+  UPDATE_ITSTATEMENT_ORDER: 'UPDATE_ITSTATEMENT_ORDER',
 
   CREATE_NEW_TEST: 'CREATE_NEW_TEST',
   OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
@@ -65,6 +66,13 @@ export const updateItStatementText = (text, itId) => ({
   itId,
   text,
 });
+
+export const updateItStatementOrder = (reorderedIt) => {
+  return {
+    type: actionTypes.UPDATE_ITSTATEMENT_ORDER,
+    reorderedIt,
+  };
+};
 
 export const createNewTest = () => ({
   type: actionTypes.CREATE_NEW_TEST,

--- a/src/context/actions/accTestCaseActions.js
+++ b/src/context/actions/accTestCaseActions.js
@@ -66,10 +66,11 @@ export const updateItStatementText = (text, itId) => ({
   text,
 });
 
-export const updateItStatementOrder = (reorderedIt) => {
+export const updateItStatementOrder = (reorderedIt, describeId) => {
   return {
     type: actionTypes.UPDATE_ITSTATEMENT_ORDER,
     reorderedIt,
+    describeId,
   };
 };
 
@@ -89,9 +90,4 @@ export const updateImportFilePath = (fileName, filePath) => ({
   type: actionTypes.UPDATE_FILE_PATH,
   fileName,
   filePath,
-});
-
-// the below have no corresponding functions in Reducer
-export const toggleAcc = () => ({
-  type: actionTypes.TOGGLE_ACC,
 });

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -230,6 +230,17 @@ export const accTestCaseReducer = (state, action) => {
         },
       };
     }
+    case actionTypes.UPDATE_ITSTATEMENT_ORDER: {
+      const { reorderedIt } = action;
+
+      return {
+        ...state,
+        itStatements: {
+          ...itStatements,
+          allIds: reorderedIt,
+        },
+      };
+    }
     case actionTypes.CREATE_NEW_TEST: {
       return {
         ...state,

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -158,6 +158,17 @@ export const accTestCaseReducer = (state, action) => {
         },
       };
     }
+    case actionTypes.UPDATE_DESCRIBE_ORDER: {
+      const { reorderedDescribe } = action;
+
+      return {
+        ...state,
+        describeBlocks: {
+          ...describeBlocks,
+          allIds: reorderedDescribe,
+        },
+      };
+    }
     case actionTypes.ADD_ITSTATEMENT: {
       const { describeId } = action;
       const itId = `it${state.itId}`;

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -109,11 +109,11 @@ export const accTestCaseReducer = (state, action) => {
       return {
         ...state,
         describeBlocks: {
-          byIds: newDescById,
+          byId: newDescById,
           allIds: newDescAllIds,
         },
         itStatements: {
-          byIds: newItById,
+          byId: newItById,
           allIds: newItAllIds,
         },
       };
@@ -190,14 +190,14 @@ export const accTestCaseReducer = (state, action) => {
     }
     case actionTypes.UPDATE_ITSTATEMENT_TEXT: {
       const { itId, text } = action;
-      const byIds = { ...itStatements.byId };
+      const byId = { ...itStatements.byId };
       const block = { ...itStatements.byId[itId] };
       return {
         ...state,
         itStatements: {
           ...itStatements,
           byId: {
-            ...byIds,
+            ...byId,
             [itId]: {
               ...block,
               text,

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -90,27 +90,31 @@ export const accTestCaseReducer = (state, action) => {
     }
     case actionTypes.DELETE_DESCRIBE_BLOCK: {
       const { describeId } = action;
+      const newDescById = { ...describeBlocks.byId };
+      const newItById = { ...itStatements.byId };
+      const newItAllIds = { ...itStatements.allIds };
 
       // delete it from describeBlocks.byId
-      delete describeBlocks.byId[describeId];
+      delete newDescById[describeId];
       // delete it from describeBlocks.allIds
-      const newAllIds = describeBlocks.allIds.filter((id) => id !== describeId);
+      const newDescAllIds = describeBlocks.allIds.filter((id) => id !== describeId);
 
       // delete from itStatements.byId
       itStatements.allIds[describeId].forEach((itId) => {
-        delete itStatements.byId[itId];
+        delete newItById[itId];
       });
       // delete from itStatements.allIds
-      delete itStatements.allIds[describeId];
+      delete newItAllIds[describeId];
 
       return {
         ...state,
         describeBlocks: {
-          ...describeBlocks,
-          allIds: newAllIds,
+          byIds: newDescById,
+          allIds: newDescAllIds,
         },
         itStatements: {
-          ...itStatements,
+          byIds: newItById,
+          allIds: newItAllIds,
         },
       };
     }

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -3,7 +3,7 @@ import { actionTypes } from '../actions/accTestCaseActions';
 
 export const AccTestCaseContext = createContext([]);
 
-// ### revisit - is this the default state which is ammended by the reducer?
+
 export const accTestCaseState = {
   modalOpen: false,
 
@@ -30,20 +30,8 @@ export const accTestCaseState = {
     },
     allIds: ['it0'],
   },
-  statements: {
-    byId: {
-      statement0: {
-        id: 'statement0',
-        itId: 'it0',
-        describeId: 'describe0',
-        type: 'render',
-        props: [],
-      },
-    },
-    allIds: ['statement0'],
-    fileName: '',
-    filePath: '',
-  },
+  fileName: '',
+  filePath: '',
 };
 
 /* ---------------------------- Helper Functions ---------------------------- */
@@ -80,12 +68,10 @@ export const accTestCaseReducer = (state, action) => {
 
   let describeBlocks;
   let itStatements;
-  let statements;
 
   if (state && action) {
     describeBlocks = { ...state.describeBlocks };
     itStatements = { ...state.itStatements };
-    statements = { ...state.statements };
   }
 
   switch (action.type) {
@@ -113,7 +99,6 @@ export const accTestCaseReducer = (state, action) => {
       const allIds = describeBlocks.allIds.filter((id) => id !== describeId);
 
       const itStatementAllIds = deleteChildren(itStatements, describeId, 'describeId');
-      const statementAllIds = deleteChildren(statements, describeId, 'describeId');
 
       return {
         ...state,
@@ -130,13 +115,6 @@ export const accTestCaseReducer = (state, action) => {
             ...itStatements.byId,
           },
           allIds: [...itStatementAllIds],
-        },
-        statements: {
-          ...statements,
-          byId: {
-            ...statements.byId,
-          },
-          allIds: [...statementAllIds],
         },
       };
     }
@@ -192,7 +170,6 @@ export const accTestCaseReducer = (state, action) => {
       const byId = { ...itStatements.byId };
       delete byId[itId];
       const allIds = itStatements.allIds.filter((id) => id !== itId);
-      const statementAllIds = deleteChildren(statements, itId, 'itId');
 
       return {
         ...state,
@@ -202,13 +179,6 @@ export const accTestCaseReducer = (state, action) => {
             ...byId,
           },
           allIds: [...allIds],
-        },
-        statements: {
-          ...statements,
-          byId: {
-            ...statements.byId,
-          },
-          allIds: [...statementAllIds],
         },
       };
     }
@@ -252,10 +222,6 @@ export const accTestCaseReducer = (state, action) => {
           byId: {},
           allIds: [],
         },
-        statements: {
-          byId: {},
-          allIds: [],
-        },
       };
     }
     case actionTypes.OPEN_INFO_MODAL: {
@@ -274,11 +240,8 @@ export const accTestCaseReducer = (state, action) => {
       const { fileName, filePath } = action;
       return {
         ...state,
-        statements: {
-          ...state.statements,
-          fileName,
-          filePath,
-        },
+        fileName,
+        filePath,
       };
     }
     default:

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -788,7 +788,7 @@ function useGenerateTest(test, projectFilePath) {
     /* ------------------------------------------ ACCESSIBILITY TESTING ------------------------------------------ */
     
     const addAccImportStatements = () => {
-      let { filePath } = accTestCase.statements;
+      let { filePath } = accTestCase;
       filePath = path.relative(projectFilePath, filePath);
       filePath = filePath.replace(/\\/g, '/');
 

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -819,53 +819,51 @@ function useGenerateTest(test, projectFilePath) {
     const addAccItStatements = (descId) => {
       const { itStatements } = accTestCase;
       
-      itStatements.allIds.forEach((itId) => {
-        if (itStatements.byId[itId].describeId === descId) {
-          testFileCode += `it('${itStatements.byId[itId].text}', (done) => {
-          // exclude tests that are incompatible
-            const config = {
-              rules: {
-                'color-contrast': { enabled: false },
-                'link-in-text-block': { enabled: false }
-              }
-            };
-        
-            // get language tag from imported html file and assign to jsdom document
-            const langTag = html.match(/<html lang="(.*)"/);
-            if (langTag) document.documentElement.lang = langTag[1];
-            document.documentElement.innerHTML = html.toString();
-        
-            axe.run(config, async (err, { violations }) => {
-              if (err) {
-                console.log('err: ', err);
-                done();
-              }
-        
-              if (violations.length === 0) {
-                console.log('Congrats! Keep up the good work, you have 0 known violations!');
-              } else {
-                violations.forEach(axeViolation => {
-                  const whereItFailed = axeViolation.nodes.map(node => node.html);
-                  // const failureSummary = axeViolation.nodes.map(node => node.failureSummary);
-            
-                  const { description, help, helpUrl } = axeViolation;
-        
-                  console.log('---------',
-                    '\\nTEST DESCRIPTION: ', description,
-                    '\\nISSUE: ', help,
-                    '\\nMORE INFO: ', helpUrl,
-                    '\\nWHERE IT FAILED: ', whereItFailed,
-                    // '\\nhow to fix: ', failureSummary
-                  );
-                });
-              }
-        
-              expect(err).toBe(null);
-              expect(violations).toHaveLength(0);
+      itStatements.allIds[descId].forEach((itId) => {
+        testFileCode += `it('${itStatements.byId[itId].text}', (done) => {
+        // exclude tests that are incompatible
+          const config = {
+            rules: {
+              'color-contrast': { enabled: false },
+              'link-in-text-block': { enabled: false }
+            }
+          };
+      
+          // get language tag from imported html file and assign to jsdom document
+          const langTag = html.match(/<html lang="(.*)"/);
+          if (langTag) document.documentElement.lang = langTag[1];
+          document.documentElement.innerHTML = html.toString();
+      
+          axe.run(config, async (err, { violations }) => {
+            if (err) {
+              console.log('err: ', err);
               done();
-            });
-          })`;
-        }
+            }
+      
+            if (violations.length === 0) {
+              console.log('Congrats! Keep up the good work, you have 0 known violations!');
+            } else {
+              violations.forEach(axeViolation => {
+                const whereItFailed = axeViolation.nodes.map(node => node.html);
+                // const failureSummary = axeViolation.nodes.map(node => node.failureSummary);
+          
+                const { description, help, helpUrl } = axeViolation;
+      
+                console.log('---------',
+                  '\\nTEST DESCRIPTION: ', description,
+                  '\\nISSUE: ', help,
+                  '\\nMORE INFO: ', helpUrl,
+                  '\\nWHERE IT FAILED: ', whereItFailed,
+                  // '\\nhow to fix: ', failureSummary
+                );
+              });
+            }
+      
+            expect(err).toBe(null);
+            expect(violations).toHaveLength(0);
+            done();
+          });
+        })`;
         testFileCode += '\n';
       });
     };


### PR DESCRIPTION
# Adding Drag and Drop Functionality to the Accessibility Portion of Spearmint
<hr>

The following changes reflect the addition of the Drag and Drop functionality to the accessibility portion of Spearmint.
Describe blocks and it statements can now be rearranged with the state changing accordingly.
In addition to the new features, this PR also reflects code clean-up and refactoring for code optimization.
  
![Hnet-image](https://user-images.githubusercontent.com/45021525/111888408-a0ce7100-89b2-11eb-9f65-a2e3d5626a5b.gif)

## The Following Changes Took Place:

* Added drag n drog functionality to accessibility describe blocks 
* Implemented drag and drop functionality for it statements
* Fixed extra component wrapper on Acc/DescribeRenderer
* Removed 'statements' from accessibility test components
* Removed unnecessary 'statements' in acc
* Refactored Acc itStatements.allIds as obj + clean up
* Refactored acc reducer to not alter state
* Fixed error on delete describe block functionality in accTestCaseReducer

## This PR alters 8 files:

```
| src/App.jsx                                        
  | src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
  | src/components/TestCase/AccTestCase.jsx     
        | /AccTestComponent/ItRenderer/ItRenderer.tsx 
            | DescribeRenderer/DescribeRenderer.tsx       
  | src/context/actions/accTestCaseActions.js          
  | src/context/reducers/accTestCaseReducer.js         
  | src/context/useGenerateTest.jsx
```
Co-authored-by: Gabriel Christo  45021525+bielchristo@users.noreply.github.com

Co-authored-by: Annie Shin 73931127+annieshinn@users.noreply.github.com

Co-authored-by: Alfred Sta. Iglesia  75825642+astaiglesia@users.noreply.github.com