### PR TITLE
Adding React (Enzyme) and Puppeteer Axe-Core Integrations for Accessibility Testing in Spearmint

### DIFF
--- a/src/components/AccTestComponent/AccTestTypes/AccTestTypes.module.scss
+++ b/src/components/AccTestComponent/AccTestTypes/AccTestTypes.module.scss
@@ -4,10 +4,10 @@
 
 #AccTestTypesLabel {
   display: block;
-  // margin-bottom: 6px;
+  margin-bottom: 6px;
 }
 
 .AccTestTypesInput{
-  margin-top: 10px;
+  margin-top: 4px;
   min-height: 35px;
 }

--- a/src/components/AccTestComponent/AccTestTypes/AccTestTypes.module.scss
+++ b/src/components/AccTestComponent/AccTestTypes/AccTestTypes.module.scss
@@ -1,0 +1,8 @@
+#AccTestTypesComponent{
+  margin-right: 35px;
+}
+
+#AccTestTypesLabel {
+  display: block;
+  margin-bottom: 6px;
+}

--- a/src/components/AccTestComponent/AccTestTypes/AccTestTypes.module.scss
+++ b/src/components/AccTestComponent/AccTestTypes/AccTestTypes.module.scss
@@ -4,5 +4,10 @@
 
 #AccTestTypesLabel {
   display: block;
-  margin-bottom: 6px;
+  // margin-bottom: 6px;
+}
+
+.AccTestTypesInput{
+  margin-top: 10px;
+  min-height: 35px;
 }

--- a/src/components/AccTestComponent/AccTestTypes/AccTestTypes.tsx
+++ b/src/components/AccTestComponent/AccTestTypes/AccTestTypes.tsx
@@ -11,7 +11,7 @@ const AccTestTypes = ({ dispatch, action, currTypes }) => {
       <label id={styles.AccTestTypesLabel} for='accTestTypes'>
         Choose Type of Accessibility Test
       </label>
-      <select value={currTypes} id='accTestTypes' onChange={handleChange}>
+      <select value={currTypes} id='accTestTypes' className={styles.AccTestTypesInput} onChange={handleChange}>
         <option value='html'>HTML</option>
         <option value='react'>React</option>
         <option value='puppeteer'>Puppeteer</option>

--- a/src/components/AccTestComponent/AccTestTypes/AccTestTypes.tsx
+++ b/src/components/AccTestComponent/AccTestTypes/AccTestTypes.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 
-const AccTestTypes = ({ dispatch, action }) => {
+const AccTestTypes = ({ dispatch, action, currTypes }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(action(e.target.value));
   };
 
   return (
     <div id='sampleAccTest'>
-      <label for='accTestTypes'>Choose Type of Accessibility Test:</label>
-      <select value={null} id='accTestTypes' onChange={handleChange}>
+      <label for='accTestTypes'>Choose Type of Accessibility Test:  </label>
+      <select value={currTypes} id='accTestTypes' onChange={handleChange}>
         <option value='html'>HTML</option>
         <option value='react'>React</option>
         <option value='puppeteer'>Puppeteer</option>

--- a/src/components/AccTestComponent/AccTestTypes/AccTestTypes.tsx
+++ b/src/components/AccTestComponent/AccTestTypes/AccTestTypes.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styles from './AccTestTypes.module.scss';
 
 const AccTestTypes = ({ dispatch, action, currTypes }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -6,8 +7,10 @@ const AccTestTypes = ({ dispatch, action, currTypes }) => {
   };
 
   return (
-    <div id='sampleAccTest'>
-      <label for='accTestTypes'>Choose Type of Accessibility Test:  </label>
+    <div id={styles.AccTestTypesComponent}>
+      <label id={styles.AccTestTypesLabel} for='accTestTypes'>
+        Choose Type of Accessibility Test
+      </label>
       <select value={currTypes} id='accTestTypes' onChange={handleChange}>
         <option value='html'>HTML</option>
         <option value='react'>React</option>

--- a/src/components/AccTestComponent/AccTestTypes/AccTestTypes.tsx
+++ b/src/components/AccTestComponent/AccTestTypes/AccTestTypes.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+const AccTestTypes = ({ dispatch, action }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(action(e.target.value));
+  };
+
+  return (
+    <div id='sampleAccTest'>
+      <label for='accTestTypes'>Choose Type of Accessibility Test:</label>
+      <select value={null} id='accTestTypes' onChange={handleChange}>
+        <option value='html'>HTML</option>
+        <option value='react'>React</option>
+        <option value='puppeteer'>Puppeteer</option>
+      </select>
+    </div>
+  );
+};
+
+export default AccTestTypes;

--- a/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
+++ b/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+const AccTestTypes = ({ dispatch, action }) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(action(e.target.value));
+  };
+
+  return (
+    <div>
+      <label>URL to be Tested:</label>
+      <input id='taoan456'>
+      </input>
+      {/* <label for='accTestTypes'>Choose Type of Accessibility Test:  </label>
+      <select value={currTypes} id='accTestTypes' onChange={handleChange}>
+        <option value='html'>HTML</option>
+        <option value='react'>React</option>
+        <option value='puppeteer'>Puppeteer</option>
+      </select> */}
+    </div>
+  );
+};
+
+export default AccTestTypes;

--- a/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
+++ b/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
@@ -10,7 +10,7 @@ const AccTestTypes = ({ dispatch, action }) => {
   return (
     <div id={styles.AccTestTypesComponent}>
       <label id={styles.AccTestTypesLabel}>URL to be Tested:</label>
-      <input onChange = { handleChange }>
+      <input onChange = { handleChange } placeholder='https://sample.io'>
       </input>
     </div>
   );

--- a/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
+++ b/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+// import styles used in AccTestTypes for input labels et al.
+import styles from '../AccTestTypes/AccTestTypes.module.scss';
 
 const AccTestTypes = ({ dispatch, action }) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -6,8 +8,8 @@ const AccTestTypes = ({ dispatch, action }) => {
   };
 
   return (
-    <div>
-      <label>URL to be Tested:</label>
+    <div id={styles.AccTestTypesComponent}>
+      <label id={styles.AccTestTypesLabel}>URL to be Tested:</label>
       <input onChange = { handleChange }>
       </input>
     </div>

--- a/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
+++ b/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
@@ -8,7 +8,7 @@ const AccTestTypes = ({ dispatch, action }) => {
   return (
     <div>
       <label>URL to be Tested:</label>
-      <input id='taoan456'>
+      <input id='taoan456'  onChange={handleChange}>
       </input>
       {/* <label for='accTestTypes'>Choose Type of Accessibility Test:  </label>
       <select value={currTypes} id='accTestTypes' onChange={handleChange}>

--- a/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
+++ b/src/components/AccTestComponent/PuppeteerUrl/PuppeteerUrl.tsx
@@ -8,14 +8,8 @@ const AccTestTypes = ({ dispatch, action }) => {
   return (
     <div>
       <label>URL to be Tested:</label>
-      <input id='taoan456'  onChange={handleChange}>
+      <input onChange = { handleChange }>
       </input>
-      {/* <label for='accTestTypes'>Choose Type of Accessibility Test:  </label>
-      <select value={currTypes} id='accTestTypes' onChange={handleChange}>
-        <option value='html'>HTML</option>
-        <option value='react'>React</option>
-        <option value='puppeteer'>Puppeteer</option>
-      </select> */}
     </div>
   );
 };

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -16,7 +16,7 @@ const Modal = ({
   dispatchTestCase,
   createTest,
   testType = null,
-  puppeteerUrl = null,
+  puppeteerUrl = 'sample.io',
 }) => {
   const { copySuccess, codeRef, handleCopy } = useCopy();
   const { handleNewTest } = useNewTest(

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -15,6 +15,7 @@ const Modal = ({
   dispatchToMockData,
   dispatchTestCase,
   createTest,
+  testType = null,
 }) => {
   const { copySuccess, codeRef, handleCopy } = useCopy();
   const { handleNewTest } = useNewTest(
@@ -24,7 +25,7 @@ const Modal = ({
     closeModal,
   );
 
-  const script = useGenerateScript(title);
+  const script = useGenerateScript(title, testType);
 
   const modalStyles = {
     overlay: {
@@ -61,6 +62,15 @@ const Modal = ({
                 <code ref={codeRef}>
                   {script}
                 </code>
+
+                {testType === 'react'
+                  ?
+                    <p id={styles.endpoint}>
+                    Requires React version 16 or less.
+                    </p>
+                  : null
+                }
+
                 <p id={styles.endpoint}>
                   Note if you are using Create React App do not install jest
                 </p>

--- a/src/components/Modals/Modal.jsx
+++ b/src/components/Modals/Modal.jsx
@@ -16,6 +16,7 @@ const Modal = ({
   dispatchTestCase,
   createTest,
   testType = null,
+  puppeteerUrl = null,
 }) => {
   const { copySuccess, codeRef, handleCopy } = useCopy();
   const { handleNewTest } = useNewTest(
@@ -25,7 +26,7 @@ const Modal = ({
     closeModal,
   );
 
-  const script = useGenerateScript(title, testType);
+  const script = useGenerateScript(title, testType, puppeteerUrl);
 
   const modalStyles = {
     overlay: {

--- a/src/components/Modals/modalHooks.js
+++ b/src/components/Modals/modalHooks.js
@@ -54,7 +54,13 @@ export function useGenerateScript(test, testType = null) {
         );
       }
       if (testType === 'puppeteer') {
-        return 'puppeteer run script';
+        return (
+          `cd ${projectFilePath}
+          npm i -D axe-core puppeteer
+          node <fileName> <urlToTest>
+          `
+        );
+        
       }
       return 'error';
     case 'react':

--- a/src/components/Modals/modalHooks.js
+++ b/src/components/Modals/modalHooks.js
@@ -4,13 +4,6 @@ import { toggleModal, setTestCase, updateFile } from '../../context/actions/glob
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import styles from './ExportFileModal.module.scss';
 
-// taoan delete
-import {
-  
-  accTestCaseState,
-
-} from '../../context/reducers/accTestCaseReducer';
-
 export function useCopy() {
   const [copySuccess, setCopySuccess] = useState(false);
   const codeRef = useRef(null);
@@ -42,7 +35,7 @@ export function useNewTest(dispatchToMockData, dispatchTestCase, createTest, clo
   return { handleNewTest };
 }
 
-export function useGenerateScript(test, testType = null) {
+export function useGenerateScript(test, testType = null, puppeteerUrl = null) {
   const [{ projectFilePath }] = useContext(GlobalContext);
   switch (test) {
     case 'acc':
@@ -61,11 +54,10 @@ export function useGenerateScript(test, testType = null) {
         );
       }
       if (testType === 'puppeteer') {
-        console.log(accTestCaseState);
         return (
           `cd ${projectFilePath}
           npm i -D axe-core puppeteer
-          node <fileName> <urlToTest>
+          node <fileName> ${puppeteerUrl}
           `
         );
         

--- a/src/components/Modals/modalHooks.js
+++ b/src/components/Modals/modalHooks.js
@@ -35,7 +35,7 @@ export function useNewTest(dispatchToMockData, dispatchTestCase, createTest, clo
   return { handleNewTest };
 }
 
-export function useGenerateScript(test, testType = null, puppeteerUrl = null) {
+export function useGenerateScript(test, testType = null, puppeteerUrl = 'sample.io') {
   const [{ projectFilePath }] = useContext(GlobalContext);
   switch (test) {
     case 'acc':
@@ -57,7 +57,7 @@ export function useGenerateScript(test, testType = null, puppeteerUrl = null) {
         return (
           `cd ${projectFilePath}
           npm i -D axe-core puppeteer
-          node <fileName> ${puppeteerUrl}
+          node <YOUR_TEST_FILE_NAME.JS> ${puppeteerUrl}
           `
         );
         

--- a/src/components/Modals/modalHooks.js
+++ b/src/components/Modals/modalHooks.js
@@ -57,7 +57,7 @@ export function useGenerateScript(test, testType = null, puppeteerUrl = 'sample.
         return (
           `cd ${projectFilePath}
           npm i -D axe-core puppeteer
-          node <YOUR_TEST_FILE_NAME.JS> ${puppeteerUrl}
+          node <YOUR_DIR_PATH/TEST_FILE.JS> ${puppeteerUrl}
           `
         );
         

--- a/src/components/Modals/modalHooks.js
+++ b/src/components/Modals/modalHooks.js
@@ -4,6 +4,13 @@ import { toggleModal, setTestCase, updateFile } from '../../context/actions/glob
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import styles from './ExportFileModal.module.scss';
 
+// taoan delete
+import {
+  
+  accTestCaseState,
+
+} from '../../context/reducers/accTestCaseReducer';
+
 export function useCopy() {
   const [copySuccess, setCopySuccess] = useState(false);
   const codeRef = useRef(null);
@@ -54,6 +61,7 @@ export function useGenerateScript(test, testType = null) {
         );
       }
       if (testType === 'puppeteer') {
+        console.log(accTestCaseState);
         return (
           `cd ${projectFilePath}
           npm i -D axe-core puppeteer

--- a/src/components/Modals/modalHooks.js
+++ b/src/components/Modals/modalHooks.js
@@ -35,15 +35,28 @@ export function useNewTest(dispatchToMockData, dispatchTestCase, createTest, clo
   return { handleNewTest };
 }
 
-export function useGenerateScript(test) {
+export function useGenerateScript(test, testType = null) {
   const [{ projectFilePath }] = useContext(GlobalContext);
   switch (test) {
     case 'acc':
-      return (
-        `cd ${projectFilePath}\n` +
-        'npm i -D axe-core regenerator-runtime jest\n' +
-        'jest'
-      );
+      if (testType === 'html') {
+        return (
+          `cd ${projectFilePath}
+          npm i -D axe-core regenerator-runtime jest
+          jest`
+        );
+      }
+      if (testType === 'react') {
+        return (
+          `cd ${projectFilePath}
+          npm i -D axe-core regenerator-runtime jest enzyme enzyme-adapter-react-16
+          jest`
+        );
+      }
+      if (testType === 'puppeteer') {
+        return 'puppeteer run script';
+      }
+      return 'error';
     case 'react':
       return (
         `cd ${projectFilePath}\n` +

--- a/src/components/SearchInput/SearchInput.scss
+++ b/src/components/SearchInput/SearchInput.scss
@@ -48,7 +48,7 @@ ul.react-test-options li.option-active {
 }
 
 .flex-item {
-  width: 50%;
+  // width: 50%;
   margin-right: 7%;
   input {
     margin-top: 6px;

--- a/src/components/SearchInput/SearchInput.scss
+++ b/src/components/SearchInput/SearchInput.scss
@@ -48,7 +48,7 @@ ul.react-test-options li.option-active {
 }
 
 .flex-item {
-  // width: 50%;
+  width: 150%;
   margin-right: 7%;
   input {
     margin-top: 6px;

--- a/src/components/SearchInput/SearchInput.scss
+++ b/src/components/SearchInput/SearchInput.scss
@@ -48,7 +48,7 @@ ul.react-test-options li.option-active {
 }
 
 .flex-item {
-  width: 150%;
+  width: 200px;
   margin-right: 7%;
   input {
     margin-top: 6px;

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -78,16 +78,11 @@ const AccTestCase = () => {
           currType={testType}
         />
 
-        {testType === 'puppeteer'
-          ? (
-              <PuppeteerUrl
-                dispatch={dispatchToAccTestCase}
-                action={createPuppeteerUrl}
-              />
-            )
-          : (
-            <div>
-              <label htmlFor="fileImport">Import File From</label>
+        {testType === 'puppeteer' ? (
+          <PuppeteerUrl dispatch={dispatchToAccTestCase} action={createPuppeteerUrl} />
+        ) : (
+          <div>
+            <label htmlFor="fileImport">Import File From</label>
               <div id={styles.labelInput} style={{ width: '80%' }}>
                 <SearchInput
                   options={Object.keys(filePathMap)}

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -1,30 +1,29 @@
 import React, { useContext, useReducer } from 'react';
 import cn from 'classnames';
 import { DragDropContext, Droppable } from 'react-beautiful-dnd';
-import styles from './TestCase.module.scss';
+
 import {
   updateDescribeText,
   updateItStatementText,
   updateDescribeOrder,
   updateItStatementOrder,
+  updateFilePath,
 } from '../../context/actions/accTestCaseActions';
-import { GlobalContext } from '../../context/reducers/globalReducer';
-import SearchInput from '../SearchInput/SearchInput';
-
-import AccTestMenu from '../TestMenu/AccTestMenu';
-
-import DecribeRenderer from '../AccTestComponent/DescribeRenderer/DescribeRenderer';
-import { updateFilePath } from '../../context/actions/accTestCaseActions';
 import {
   AccTestCaseContext,
   accTestCaseState,
   accTestCaseReducer,
 } from '../../context/reducers/accTestCaseReducer';
+import { GlobalContext } from '../../context/reducers/globalReducer';
+
+import styles from './TestCase.module.scss';
+import AccTestMenu from '../TestMenu/AccTestMenu';
+import AccTestTypes from '../AccTestComponent/AccTestTypes/AccTestTypes';
+import SearchInput from '../SearchInput/SearchInput';
+import DecribeRenderer from '../AccTestComponent/DescribeRenderer/DescribeRenderer';
 
 const AccTestCase = () => {
-  const [accTestCase, dispatchToAccTestCase] = useContext(
-    AccTestCaseContext,
-  );
+  const [accTestCase, dispatchToAccTestCase] = useContext(AccTestCaseContext);
 
   const { describeBlocks, itStatements } = accTestCase;
 
@@ -70,16 +69,10 @@ const AccTestCase = () => {
       </div>
 
       <section id={styles.testCaseHeader}>
-        <div id="sampleAccTest">
-          <label for="accTestTypes">Choose Type of Accessibility Test:</label>
-
-          <select name="accTestTypes" id="accTestTypes">
-            <option value="html">HTML</option>
-            <option value="react">React</option>
-            <option value="puppeteer">Puppeteer</option>
-          </select>
-        </div>
-
+        <AccTestTypes
+          dispatch={dispatchToAccTestCase}
+          action={updateFilePath}
+        />
         <label htmlFor="fileImport">Import File From</label>
         <div id={styles.labelInput} style={{ width: '80%' }}>
           <SearchInput

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -14,7 +14,7 @@ import SearchInput from '../SearchInput/SearchInput';
 import AccTestMenu from '../TestMenu/AccTestMenu';
 
 import DecribeRenderer from '../AccTestComponent/DescribeRenderer/DescribeRenderer';
-import { updateImportFilePath } from '../../context/actions/accTestCaseActions';
+import { updateHtmlPath } from '../../context/actions/accTestCaseActions';
 import {
   AccTestCaseContext,
   accTestCaseState,
@@ -75,7 +75,7 @@ const AccTestCase = () => {
           <SearchInput
             options={Object.keys(filePathMap)}
             dispatch={dispatchToAccTestCase}
-            action={updateImportFilePath}
+            action={updateHtmlPath}
             filePathMap={filePathMap}
           />
         </div>

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -14,7 +14,7 @@ import SearchInput from '../SearchInput/SearchInput';
 import AccTestMenu from '../TestMenu/AccTestMenu';
 
 import DecribeRenderer from '../AccTestComponent/DescribeRenderer/DescribeRenderer';
-import { updateHtmlPath } from '../../context/actions/accTestCaseActions';
+import { updateFilePath } from '../../context/actions/accTestCaseActions';
 import {
   AccTestCaseContext,
   accTestCaseState,
@@ -75,7 +75,7 @@ const AccTestCase = () => {
           <SearchInput
             options={Object.keys(filePathMap)}
             dispatch={dispatchToAccTestCase}
-            action={updateHtmlPath}
+            action={updateFilePath}
             filePathMap={filePathMap}
           />
         </div>

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -75,15 +75,24 @@ const AccTestCase = () => {
           action={updateTestType}
           currType={testType}
         />
-        <label htmlFor="fileImport">Import File From</label>
-        <div id={styles.labelInput} style={{ width: '80%' }}>
-          <SearchInput
-            options={Object.keys(filePathMap)}
-            dispatch={dispatchToAccTestCase}
-            action={updateFilePath}
-            filePathMap={filePathMap}
-          />
-        </div>
+
+        {testType === 'puppeteer'
+          ? (
+            <label>URL to be tested:</label>
+            <input>
+            </input>
+          )
+          : (
+            <label htmlFor="fileImport">Import File From</label>
+            <div id={styles.labelInput} style={{ width: '80%' }}>
+              <SearchInput
+                options={Object.keys(filePathMap)}
+                dispatch={dispatchToAccTestCase}
+                action={updateFilePath}
+                filePathMap={filePathMap}
+              />
+            </div>
+          )}
 
         <DragDropContext onDragEnd={onDragEnd}>
           <Droppable

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -71,9 +71,9 @@ const AccTestCase = () => {
 
       <section id={styles.testCaseHeader}>
         <div id="sampleAccTest">
-          <label for="accTestCases">Choose Type of Accessibility Test:</label>
+          <label for="accTestTypes">Choose Type of Accessibility Test:</label>
 
-          <select name="accTestCases" id="accTestCases">
+          <select name="accTestTypes" id="accTestTypes">
             <option value="html">HTML</option>
             <option value="react">React</option>
             <option value="puppeteer">Puppeteer</option>

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -9,6 +9,7 @@ import {
   updateItStatementOrder,
   updateFilePath,
   updateTestType,
+  createPuppeteerUrl,
 } from '../../context/actions/accTestCaseActions';
 import {
   AccTestCaseContext,
@@ -20,6 +21,7 @@ import { GlobalContext } from '../../context/reducers/globalReducer';
 import styles from './TestCase.module.scss';
 import AccTestMenu from '../TestMenu/AccTestMenu';
 import AccTestTypes from '../AccTestComponent/AccTestTypes/AccTestTypes';
+import PuppeteerUrl from '../AccTestComponent/PuppeteerUrl/PuppeteerUrl';
 import SearchInput from '../SearchInput/SearchInput';
 import DecribeRenderer from '../AccTestComponent/DescribeRenderer/DescribeRenderer';
 
@@ -78,19 +80,22 @@ const AccTestCase = () => {
 
         {testType === 'puppeteer'
           ? (
-            <label>URL to be tested:</label>
-            <input>
-            </input>
-          )
-          : (
-            <label htmlFor="fileImport">Import File From</label>
-            <div id={styles.labelInput} style={{ width: '80%' }}>
-              <SearchInput
-                options={Object.keys(filePathMap)}
+              <PuppeteerUrl
                 dispatch={dispatchToAccTestCase}
-                action={updateFilePath}
-                filePathMap={filePathMap}
+                action={createPuppeteerUrl}
               />
+            )
+          : (
+            <div>
+              <label htmlFor="fileImport">Import File From</label>
+              <div id={styles.labelInput} style={{ width: '80%' }}>
+                <SearchInput
+                  options={Object.keys(filePathMap)}
+                  dispatch={dispatchToAccTestCase}
+                  action={updateFilePath}
+                  filePathMap={filePathMap}
+                />
+              </div>
             </div>
           )}
 

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -71,7 +71,7 @@ const AccTestCase = () => {
       <section id={styles.testCaseHeader}>
         <AccTestTypes
           dispatch={dispatchToAccTestCase}
-          action={updateFilePath}
+          action={updateTestType}
         />
         <label htmlFor="fileImport">Import File From</label>
         <div id={styles.labelInput} style={{ width: '80%' }}>

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -26,7 +26,7 @@ import DecribeRenderer from '../AccTestComponent/DescribeRenderer/DescribeRender
 const AccTestCase = () => {
   const [accTestCase, dispatchToAccTestCase] = useContext(AccTestCaseContext);
 
-  const { describeBlocks, itStatements } = accTestCase;
+  const { describeBlocks, itStatements, testType } = accTestCase;
 
   const [{ filePathMap }] = useContext(GlobalContext);
 
@@ -73,6 +73,7 @@ const AccTestCase = () => {
         <AccTestTypes
           dispatch={dispatchToAccTestCase}
           action={updateTestType}
+          currType={testType}
         />
         <label htmlFor="fileImport">Import File From</label>
         <div id={styles.labelInput} style={{ width: '80%' }}>

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -8,6 +8,7 @@ import {
   updateDescribeOrder,
   updateItStatementOrder,
   updateFilePath,
+  updateTestType,
 } from '../../context/actions/accTestCaseActions';
 import {
   AccTestCaseContext,

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -66,7 +66,6 @@ const AccTestCase = () => {
 
   return (
     <div id={styles.AccTestCase}>
-
       <div id="head">
         <AccTestMenu />
       </div>
@@ -118,7 +117,6 @@ const AccTestCase = () => {
           </Droppable>
         </DragDropContext>
       </section>
-
     </div>
   );
 };

--- a/src/components/TestCase/AccTestCase.jsx
+++ b/src/components/TestCase/AccTestCase.jsx
@@ -70,6 +70,16 @@ const AccTestCase = () => {
       </div>
 
       <section id={styles.testCaseHeader}>
+        <div id="sampleAccTest">
+          <label for="accTestCases">Choose Type of Accessibility Test:</label>
+
+          <select name="accTestCases" id="accTestCases">
+            <option value="html">HTML</option>
+            <option value="react">React</option>
+            <option value="puppeteer">Puppeteer</option>
+          </select>
+        </div>
+
         <label htmlFor="fileImport">Import File From</label>
         <div id={styles.labelInput} style={{ width: '80%' }}>
           <SearchInput

--- a/src/components/TestCase/AccTestCase.tsx
+++ b/src/components/TestCase/AccTestCase.tsx
@@ -68,7 +68,6 @@ const AccTestCase = () => {
       </div>
 
       <section id={styles.testCaseHeader}>
-        {/* //taotao  */}
         <div id={styles.accTestDiv}>
           <AccTestTypes
             dispatch={dispatchToAccTestCase}

--- a/src/components/TestCase/AccTestCase.tsx
+++ b/src/components/TestCase/AccTestCase.tsx
@@ -68,27 +68,30 @@ const AccTestCase = () => {
       </div>
 
       <section id={styles.testCaseHeader}>
-        <AccTestTypes
-          dispatch={dispatchToAccTestCase}
-          action={updateTestType}
-          currType={testType}
-        />
+        {/* //taotao  */}
+        <div id={styles.accTestDiv}>
+          <AccTestTypes
+            dispatch={dispatchToAccTestCase}
+            action={updateTestType}
+            currType={testType}
+          />
 
-        {testType === 'puppeteer' ? (
-          <PuppeteerUrl dispatch={dispatchToAccTestCase} action={createPuppeteerUrl} />
-        ) : (
-          <div>
-            <label htmlFor="fileImport">Import File From</label>
-              <div id={styles.labelInput} style={{ width: '80%' }}>
-                <SearchInput
-                  options={Object.keys(filePathMap)}
-                  dispatch={dispatchToAccTestCase}
-                  action={updateFilePath}
-                  filePathMap={filePathMap}
-                />
+          {testType === 'puppeteer' ? (
+            <PuppeteerUrl dispatch={dispatchToAccTestCase} action={createPuppeteerUrl} />
+          ) : (
+            <div>
+              <label htmlFor="fileImport">Import File From</label>
+                <div id={styles.labelInput} style={{ width: '80%' }}>
+                  <SearchInput
+                    options={Object.keys(filePathMap)}
+                    dispatch={dispatchToAccTestCase}
+                    action={updateFilePath}
+                    filePathMap={filePathMap}
+                  />
+                </div>
               </div>
-            </div>
-          )}
+            )}
+        </div>
 
         <DragDropContext onDragEnd={onDragEnd}>
           <Droppable

--- a/src/components/TestCase/TestCase.module.scss
+++ b/src/components/TestCase/TestCase.module.scss
@@ -149,3 +149,8 @@ div {
   align-items: center;
   margin-top: 6px;
 }
+
+#accTestDiv {
+  display: flex;
+  justify-content: flex-start;
+}

--- a/src/components/TestMenu/AccTestMenu.tsx
+++ b/src/components/TestMenu/AccTestMenu.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../context/actions/globalActions';
 import { AccTestCaseContext } from '../../context/reducers/accTestCaseReducer';
 import { useToggleModal } from './testMenuHooks';
+import AccTestTypes from '../AccTestComponent/AccTestTypes/AccTestTypes';
 
 
 const AccTestMenu = () => {
@@ -25,7 +26,7 @@ const AccTestMenu = () => {
   const [{ projectFilePath, file, exportBool }, dispatchToGlobal] = useContext(GlobalContext);
   const generateTest = useGenerateTest('acc', projectFilePath);
 
-  // setValidCode to true on load. 
+  // setValidCode to true on load.
   useEffect(() => {
     dispatchToGlobal(setValidCode(true));
   }, []);
@@ -68,6 +69,7 @@ const AccTestMenu = () => {
             dispatchToMockData={null}
             dispatchTestCase={dispatchToAccTestCase}
             createTest={createNewTest}
+            testType={accTestCase.testType}
           />
           {/* Just send user to docs on button click */}
         </div>

--- a/src/components/TestMenu/AccTestMenu.tsx
+++ b/src/components/TestMenu/AccTestMenu.tsx
@@ -70,6 +70,7 @@ const AccTestMenu = () => {
             dispatchTestCase={dispatchToAccTestCase}
             createTest={createNewTest}
             testType={accTestCase.testType}
+            puppeteerUrl={accTestCase.puppeteerUrl}
           />
           {/* Just send user to docs on button click */}
         </div>

--- a/src/components/TestMenu/AccTestMenu.tsx
+++ b/src/components/TestMenu/AccTestMenu.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../context/actions/globalActions';
 import { AccTestCaseContext } from '../../context/reducers/accTestCaseReducer';
 import { useToggleModal } from './testMenuHooks';
-import AccTestTypes from '../AccTestComponent/AccTestTypes/AccTestTypes';
 
 const AccTestMenu = () => {
   // link to accessibility testing docs url

--- a/src/components/TestMenu/AccTestMenu.tsx
+++ b/src/components/TestMenu/AccTestMenu.tsx
@@ -15,7 +15,6 @@ import { AccTestCaseContext } from '../../context/reducers/accTestCaseReducer';
 import { useToggleModal } from './testMenuHooks';
 import AccTestTypes from '../AccTestComponent/AccTestTypes/AccTestTypes';
 
-
 const AccTestMenu = () => {
   // link to accessibility testing docs url
   const accUrl = 'https://www.deque.com/axe/core-documentation/api-documentation/'; 
@@ -84,8 +83,7 @@ const AccTestMenu = () => {
           </button>
         </div>
       </div>
-    </div>
-    
+    </div> 
   );
 }
 

--- a/src/context/actions/accTestCaseActions.js
+++ b/src/context/actions/accTestCaseActions.js
@@ -16,6 +16,7 @@ export const actionTypes = {
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
 
   UPDATE_FILE_PATH: 'UPDATE_FILE_PATH',
+  UPDATE_TEST_TYPE: 'UPDATE_TEST_TYPE',
 
   // not yet implemented:
   TOGGLE_ACC: 'TOGGLE_ACC',
@@ -23,18 +24,14 @@ export const actionTypes = {
 
 /* --------------------------------- Actions -------------------------------- */
 
-export const addDescribeBlock = () => {
-  return {
-    type: actionTypes.ADD_DESCRIBE_BLOCK,
-  };
-};
+export const addDescribeBlock = () => ({
+  type: actionTypes.ADD_DESCRIBE_BLOCK,
+});
 
-export const deleteDescribeBlock = (describeId) => {
-  return {
-    type: actionTypes.DELETE_DESCRIBE_BLOCK,
-    describeId,
-  };
-};
+export const deleteDescribeBlock = (describeId) => ({
+  type: actionTypes.DELETE_DESCRIBE_BLOCK,
+  describeId,
+});
 
 export const updateDescribeText = (text, describeId) => ({
   type: actionTypes.UPDATE_DESCRIBE_TEXT,
@@ -42,12 +39,10 @@ export const updateDescribeText = (text, describeId) => ({
   describeId,
 });
 
-export const updateDescribeOrder = (reorderedDescribe) => {
-  return {
-    type: actionTypes.UPDATE_DESCRIBE_ORDER,
-    reorderedDescribe,
-  };
-};
+export const updateDescribeOrder = (reorderedDescribe) => ({
+  type: actionTypes.UPDATE_DESCRIBE_ORDER,
+  reorderedDescribe,
+});
 
 export const addItStatement = (describeId) => ({
   type: actionTypes.ADD_ITSTATEMENT,
@@ -66,28 +61,31 @@ export const updateItStatementText = (text, itId) => ({
   text,
 });
 
-export const updateItStatementOrder = (reorderedIt, describeId) => {
-  return {
-    type: actionTypes.UPDATE_ITSTATEMENT_ORDER,
-    reorderedIt,
-    describeId,
-  };
-};
+export const updateItStatementOrder = (reorderedIt, describeId) => ({
+  type: actionTypes.UPDATE_ITSTATEMENT_ORDER,
+  reorderedIt,
+  describeId,
+});
 
 export const createNewTest = () => ({
   type: actionTypes.CREATE_NEW_TEST,
 });
 
-export const openInfoModal = () => {
-  return { type: actionTypes.OPEN_INFO_MODAL };
-};
+export const openInfoModal = () => ({
+  type: actionTypes.OPEN_INFO_MODAL,
+});
 
-export const closeInfoModal = () => {
-  return { type: actionTypes.CLOSE_INFO_MODAL };
-};
+export const closeInfoModal = () => ({
+  type: actionTypes.CLOSE_INFO_MODAL,
+});
 
 export const updateFilePath = (fileName, filePath) => ({
   type: actionTypes.UPDATE_FILE_PATH,
   fileName,
   filePath,
+});
+
+export const updateTestType = (testType) => ({
+  type: actionTypes.UPDATE_TEST_TYPE,
+  testType,
 });

--- a/src/context/actions/accTestCaseActions.js
+++ b/src/context/actions/accTestCaseActions.js
@@ -17,6 +17,7 @@ export const actionTypes = {
 
   UPDATE_FILE_PATH: 'UPDATE_FILE_PATH',
   UPDATE_TEST_TYPE: 'UPDATE_TEST_TYPE',
+  CREATE_PUPPETEER_URL: 'CREATE_PUPPETEER_URL',
 
   // not yet implemented:
   TOGGLE_ACC: 'TOGGLE_ACC',
@@ -88,4 +89,9 @@ export const updateFilePath = (fileName, filePath) => ({
 export const updateTestType = (testType) => ({
   type: actionTypes.UPDATE_TEST_TYPE,
   testType,
+});
+
+export const createPuppeteerUrl = (puppeteerUrl) => ({
+  type: actionTypes.CREATE_PUPPETEER_URL,
+  puppeteerUrl,
 });

--- a/src/context/actions/accTestCaseActions.js
+++ b/src/context/actions/accTestCaseActions.js
@@ -15,7 +15,7 @@ export const actionTypes = {
   OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
 
-  UPDATE_FILE_PATH: 'UPDATE_FILE_PATH',
+  UPDATE_HTML_PATH: 'UPDATE_HTML_PATH',
 
   // not yet implemented:
   TOGGLE_ACC: 'TOGGLE_ACC',
@@ -86,8 +86,8 @@ export const closeInfoModal = () => {
   return { type: actionTypes.CLOSE_INFO_MODAL };
 };
 
-export const updateImportFilePath = (fileName, filePath) => ({
-  type: actionTypes.UPDATE_FILE_PATH,
-  fileName,
-  filePath,
+export const updateHtmlPath = (htmlFileName, htmlFilePath) => ({
+  type: actionTypes.UPDATE_HTML_PATH,
+  htmlFileName,
+  htmlFilePath,
 });

--- a/src/context/actions/accTestCaseActions.js
+++ b/src/context/actions/accTestCaseActions.js
@@ -15,7 +15,7 @@ export const actionTypes = {
   OPEN_INFO_MODAL: 'OPEN_INFO_MODAL',
   CLOSE_INFO_MODAL: 'CLOSE_INFO_MODAL',
 
-  UPDATE_HTML_PATH: 'UPDATE_HTML_PATH',
+  UPDATE_FILE_PATH: 'UPDATE_FILE_PATH',
 
   // not yet implemented:
   TOGGLE_ACC: 'TOGGLE_ACC',
@@ -86,8 +86,8 @@ export const closeInfoModal = () => {
   return { type: actionTypes.CLOSE_INFO_MODAL };
 };
 
-export const updateHtmlPath = (htmlFileName, htmlFilePath) => ({
-  type: actionTypes.UPDATE_HTML_PATH,
-  htmlFileName,
-  htmlFilePath,
+export const updateFilePath = (fileName, filePath) => ({
+  type: actionTypes.UPDATE_FILE_PATH,
+  fileName,
+  filePath,
 });

--- a/src/context/actions/accTestCaseActions.ts
+++ b/src/context/actions/accTestCaseActions.ts
@@ -28,12 +28,10 @@ export const addDescribeBlock = () => ({
   type: actionTypes.ADD_DESCRIBE_BLOCK,
 });
 
-export const deleteDescribeBlock = (describeId: string) => {
-  return {
-    type: actionTypes.DELETE_DESCRIBE_BLOCK,
-    describeId,
-  };
-};
+export const deleteDescribeBlock = (describeId: string) => ({
+  type: actionTypes.DELETE_DESCRIBE_BLOCK,
+  describeId,
+});
 
 export const updateDescribeText = (text: string, describeId: string) => ({
   type: actionTypes.UPDATE_DESCRIBE_TEXT,
@@ -41,12 +39,10 @@ export const updateDescribeText = (text: string, describeId: string) => ({
   describeId,
 });
 
-export const updateDescribeOrder = (reorderedDescribe: Array<string>) => {
-  return {
-    type: actionTypes.UPDATE_DESCRIBE_ORDER,
-    reorderedDescribe,
-  };
-};
+export const updateDescribeOrder = (reorderedDescribe: Array<string>) => ({
+  type: actionTypes.UPDATE_DESCRIBE_ORDER,
+  reorderedDescribe,
+});
 
 export const addItStatement = (describeId: string) => ({
   type: actionTypes.ADD_ITSTATEMENT,
@@ -65,13 +61,11 @@ export const updateItStatementText = (text: string, itId: string) => ({
   text,
 });
 
-export const updateItStatementOrder = (reorderedIt: Array<string>, describeId: string) => {
-  return {
-    type: actionTypes.UPDATE_ITSTATEMENT_ORDER,
-    reorderedIt,
-    describeId,
-  };
-};
+export const updateItStatementOrder = (reorderedIt: Array<string>, describeId: string) => ({
+  type: actionTypes.UPDATE_ITSTATEMENT_ORDER,
+  reorderedIt,
+  describeId,
+});
 
 export const createNewTest = () => ({
   type: actionTypes.CREATE_NEW_TEST,

--- a/src/context/actions/accTestCaseActions.ts
+++ b/src/context/actions/accTestCaseActions.ts
@@ -85,12 +85,12 @@ export const updateFilePath = (fileName: string, filePath: string) => ({
   filePath,
 });
 
-export const updateTestType = (testType) => ({
+export const updateTestType = (testType: string) => ({
   type: actionTypes.UPDATE_TEST_TYPE,
   testType,
 });
 
-export const createPuppeteerUrl = (puppeteerUrl) => ({
+export const createPuppeteerUrl = (puppeteerUrl: string) => ({
   type: actionTypes.CREATE_PUPPETEER_URL,
   puppeteerUrl,
 });

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -31,8 +31,8 @@ export const accTestCaseState = {
       describe0: ['it0'],
     },
   },
-  htmlFileName: '',
-  htmlFilePath: '',
+  fileName: '',
+  filePath: '',
 };
 
 /* ---------------------------- Helper Functions ---------------------------- */
@@ -235,12 +235,12 @@ export const accTestCaseReducer = (state, action) => {
         modalOpen: false,
       };
     }
-    case actionTypes.UPDATE_HTML_PATH: {
-      const { htmlFileName, htmlFilePath } = action;
+    case actionTypes.UPDATE_FILE_PATH: {
+      const { fileName, filePath } = action;
       return {
         ...state,
-        htmlFileName,
-        htmlFilePath,
+        fileName,
+        filePath,
       };
     }
     default:

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -31,8 +31,8 @@ export const accTestCaseState = {
       describe0: ['it0'],
     },
   },
-  fileName: '',
-  filePath: '',
+  htmlFileName: '',
+  htmlFilePath: '',
 };
 
 /* ---------------------------- Helper Functions ---------------------------- */
@@ -235,12 +235,12 @@ export const accTestCaseReducer = (state, action) => {
         modalOpen: false,
       };
     }
-    case actionTypes.UPDATE_FILE_PATH: {
-      const { fileName, filePath } = action;
+    case actionTypes.UPDATE_HTML_PATH: {
+      const { htmlFileName, htmlFilePath } = action;
       return {
         ...state,
-        fileName,
-        filePath,
+        htmlFileName,
+        htmlFilePath,
       };
     }
     default:

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -34,6 +34,7 @@ export const accTestCaseState = {
   fileName: '',
   filePath: '',
   testType: 'html',
+  puppeteerUrl: '',
 };
 
 /* ---------------------------- Helper Functions ---------------------------- */
@@ -249,6 +250,13 @@ export const accTestCaseReducer = (state, action) => {
       return {
         ...state,
         testType,
+      };
+    }
+    case actionTypes.CREATE_PUPPETEER_URL: {
+      const { puppeteerUrl } = action;
+      return {
+        ...state,
+        puppeteerUrl,
       };
     }
     default:

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -33,6 +33,7 @@ export const accTestCaseState = {
   },
   fileName: '',
   filePath: '',
+  testType: 'html',
 };
 
 /* ---------------------------- Helper Functions ---------------------------- */
@@ -241,6 +242,13 @@ export const accTestCaseReducer = (state, action) => {
         ...state,
         fileName,
         filePath,
+      };
+    }
+    case actionTypes.UPDATE_TEST_TYPE: {
+      const { testType } = action;
+      return {
+        ...state,
+        testType,
       };
     }
     default:

--- a/src/context/reducers/accTestCaseReducer.js
+++ b/src/context/reducers/accTestCaseReducer.js
@@ -34,7 +34,7 @@ export const accTestCaseState = {
   fileName: '',
   filePath: '',
   testType: 'html',
-  puppeteerUrl: '',
+  puppeteerUrl: 'sample.io',
 };
 
 /* ---------------------------- Helper Functions ---------------------------- */

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -792,7 +792,7 @@ function useGenerateTest(test, projectFilePath) {
       filePath = path.relative(projectFilePath, filePath);
       filePath = filePath.replace(/\\/g, '/');
 
-      testFileCode += JSON.stringify(accTestCase);
+      // testFileCode += JSON.stringify(accTestCase);
 
       testFileCode += `
         const axe = require('axe-core');
@@ -951,16 +951,9 @@ function useGenerateTest(test, projectFilePath) {
       `;
       });
     };
-
-    const axeCoreInvocation = () => {`
-      // Inject axe source code
-      ${axeCore.source}
-      // Run axe
-      axe.run();
-    `}
     
-     const addAccPuppeteer = () => {
-        `
+    const addAccPuppeteer = () => {
+      testFileCode += `
         const puppeteer = require('puppeteer');
         const axeCore = require('axe-core');
         const { parse: parseURL } = require('url');
@@ -988,7 +981,12 @@ function useGenerateTest(test, projectFilePath) {
             await page.goto(url);
 
             // Inject and run axe-core
-            const handle = await page.evaluateHandle(axeCoreInvocation());
+            const handle = await page.evaluateHandle(\`
+              // Inject axe source code
+              \${axeCore.source}
+              // Run axe
+              axe.run();
+            \`);
 
             // Get the results from 'axe.run()'.
             results = await handle.jsonValue();
@@ -1041,7 +1039,7 @@ function useGenerateTest(test, projectFilePath) {
             process.exit(1);
           });
         `
-     };
+    };
 
      //const generatePuppeteerScriptTag = () => {`"node <replaceWithJavascriptTestFileName.js> ${url}"`}
 

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -877,6 +877,7 @@ function useGenerateTest(test, projectFilePath) {
     }
 
     const addAccBeforeAll = () => {
+      const { fileName } = accTestCase;
       testFileCode += `
         let options;`;
 
@@ -907,7 +908,7 @@ function useGenerateTest(test, projectFilePath) {
       } else if (usesReact) {
         testFileCode += `
         const linkComponent = mountToDoc(
-          < Link />
+          < ${fileName.split('.')[0]} />
         );
         linkNode = linkComponent.getDOMNode();
         `;

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -792,7 +792,7 @@ function useGenerateTest(test, projectFilePath) {
       filePath = path.relative(projectFilePath, filePath);
       filePath = filePath.replace(/\\/g, '/');
 
-      testFileCode += JSON.stringify(accTestCase);
+      // testFileCode += JSON.stringify(accTestCase);
 
       testFileCode += `
         const axe = require('axe-core');

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -836,6 +836,7 @@ function useGenerateTest(test, projectFilePath) {
           } else {
             violations.forEach(axeViolation => {
               const whereItFailed = axeViolation.nodes.map(node => node.html);
+              // uncomment the line(s) below to see suggestions on how to fix accessibility issues
               // const failureSummary = axeViolation.nodes.map(node => node.failureSummary);
         
               const { description, help, helpUrl } = axeViolation;
@@ -845,7 +846,7 @@ function useGenerateTest(test, projectFilePath) {
                 '\\nISSUE: ', help,
                 '\\nMORE INFO: ', helpUrl,
                 '\\nWHERE IT FAILED: ', whereItFailed,
-                // '\\nhow to fix: ', failureSummary
+                // '\\nHOW TO FIX: ', failureSummary
               );
             });
           }
@@ -1014,6 +1015,7 @@ function useGenerateTest(test, projectFilePath) {
             const violations = results;
             violations.forEach(axeViolation => {
               const whereItFailed = axeViolation.nodes.map(node => node.html);
+              // uncomment the line(s) below to see suggestions on how to fix accessibility issues
               // const failureSummary = axeViolation.nodes.map(node => node.failureSummary);
 
               const { description, help, helpUrl } = axeViolation;
@@ -1028,7 +1030,7 @@ function useGenerateTest(test, projectFilePath) {
                 helpUrl,
                 '\\nWHERE IT FAILED: ',
                 whereItFailed
-                // '\\nhow to fix: ', failureSummary
+                // '\\nHOW TO FIX: ', failureSummary
               );
             });
           })
@@ -1038,8 +1040,6 @@ function useGenerateTest(test, projectFilePath) {
           });
         `
     };
-
-     //const generatePuppeteerScriptTag = () => {`"node <replaceWithJavascriptTestFileName.js> ${url}"`}
 
     switch (test) {
       case 'acc':

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -788,9 +788,9 @@ function useGenerateTest(test, projectFilePath) {
     /* ------------------------------------------ ACCESSIBILITY TESTING ------------------------------------------ */
     
     const addAccImportStatements = () => {
-      let { filePath } = accTestCase;
-      filePath = path.relative(projectFilePath, filePath);
-      filePath = filePath.replace(/\\/g, '/');
+      let { htmlFilePath } = accTestCase;
+      htmlFilePath = path.relative(projectFilePath, htmlFilePath);
+      htmlFilePath = htmlFilePath.replace(/\\/g, '/');
 
       // testFileCode += JSON.stringify(accTestCase);
 
@@ -801,7 +801,7 @@ function useGenerateTest(test, projectFilePath) {
         const fs = require('fs');
         
         const html = fs.readFileSync(path.resolve(__dirname,
-          '../${filePath}'), 'utf8');
+          '../${htmlFilePath}'), 'utf8');
         
       `;
     };

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -792,8 +792,6 @@ function useGenerateTest(test, projectFilePath) {
       filePath = path.relative(projectFilePath, filePath);
       filePath = filePath.replace(/\\/g, '/');
 
-      // testFileCode += JSON.stringify(accTestCase);
-
       testFileCode += `
         const axe = require('axe-core');
         const regeneratorRuntime = require('regenerator-runtime');`;
@@ -831,7 +829,6 @@ function useGenerateTest(test, projectFilePath) {
     };
 
     const addAccPrint = () => {
-      testFileCode += JSON.stringify(accTestCase);
       testFileCode += `
         const print = (violations) => {
           if (violations.length === 0) {

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -954,8 +954,6 @@ function useGenerateTest(test, projectFilePath) {
     };
     
     const addAccPuppeteer = () => {
-      // taotao
-      testFileCode += JSON.stringify(accTestCase.puppeteerUrl);
       testFileCode += `
         const puppeteer = require('puppeteer');
         const axeCore = require('axe-core');

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -792,7 +792,7 @@ function useGenerateTest(test, projectFilePath) {
       filePath = path.relative(projectFilePath, filePath);
       filePath = filePath.replace(/\\/g, '/');
 
-      // testFileCode += JSON.stringify(accTestCase);
+      testFileCode += JSON.stringify(accTestCase);
 
       testFileCode += `
         const axe = require('axe-core');

--- a/src/context/useGenerateTest.jsx
+++ b/src/context/useGenerateTest.jsx
@@ -831,6 +831,7 @@ function useGenerateTest(test, projectFilePath) {
     };
 
     const addAccPrint = () => {
+      testFileCode += JSON.stringify(accTestCase);
       testFileCode += `
         const print = (violations) => {
           if (violations.length === 0) {
@@ -953,6 +954,8 @@ function useGenerateTest(test, projectFilePath) {
     };
     
     const addAccPuppeteer = () => {
+      // taotao
+      testFileCode += JSON.stringify(accTestCase.puppeteerUrl);
       testFileCode += `
         const puppeteer = require('puppeteer');
         const axeCore = require('axe-core');
@@ -1047,22 +1050,26 @@ function useGenerateTest(test, projectFilePath) {
       case 'acc':
         var accTestCase = testState;
         if (accTestCase.testType === 'puppeteer') {
-          return addAccPuppeteer(),
-          (testFileCode = beautify(testFileCode, {
-            indent_size: 2,
-            space_in_empty_paren: true,
-            e4x: true,
-          }))
+          return (
+            addAccPuppeteer(),
+            (testFileCode = beautify(testFileCode, {
+              indent_size: 2,
+              space_in_empty_paren: true,
+              e4x: true,
+            }))
+          )
+        } else {
+          return (
+            addAccImportStatements(),
+            addAccDescribeBlocks(),
+            (testFileCode = beautify(testFileCode, {
+              indent_size: 2,
+              space_in_empty_paren: true,
+              e4x: true,
+            }))
+          );
         }
-        return (
-          addAccImportStatements(),
-          addAccDescribeBlocks(),
-          (testFileCode = beautify(testFileCode, {
-            indent_size: 2,
-            space_in_empty_paren: true,
-            e4x: true,
-          }))
-        );
+        
       case 'react':
         var reactTestCase = testState;
         var mockData = mockDataState;

--- a/src/pages/TestFile/TestFile.jsx
+++ b/src/pages/TestFile/TestFile.jsx
@@ -4,7 +4,6 @@ import ReactModal from 'react-modal';
 import styles from '../../components/Modals/ExportFileModal.module.scss';
 
 // may be able to delete toggleReact, etc. from their respective action files
-
 import ReactTestCase from '../../components/TestCase/ReactTestCase';
 
 import {

--- a/src/pages/TestFile/TestFile.jsx
+++ b/src/pages/TestFile/TestFile.jsx
@@ -110,7 +110,7 @@ const TestFile = () => {
         <div id={styles.body}>
           <p id={styles.text}>What would you like to test?</p>
           <span id={styles.newTestButtons}>
-            <button id={styles.save} onClick={() => handleToggle('acc')}>
+            <button id={styles.save} autoFocus onClick={() => handleToggle('acc')}>
               Accessibility
             </button>
             <button id={styles.save} onClick={() => handleToggle('endpoint')}>
@@ -122,7 +122,7 @@ const TestFile = () => {
             <button id={styles.save} onClick={() => handleToggle('puppeteer')}>
               Puppeteer
             </button>
-            <button id={styles.save} autoFocus onClick={() => handleToggle('react')}>
+            <button id={styles.save} onClick={() => handleToggle('react')}>
               React
             </button>
             <button id={styles.save} onClick={() => handleToggle('redux')}>

--- a/src/pages/TestFile/TestFile.jsx
+++ b/src/pages/TestFile/TestFile.jsx
@@ -110,23 +110,23 @@ const TestFile = () => {
         <div id={styles.body}>
           <p id={styles.text}>What would you like to test?</p>
           <span id={styles.newTestButtons}>
+            <button id={styles.save} onClick={() => handleToggle('acc')}>
+              Accessibility
+            </button>
+            <button id={styles.save} onClick={() => handleToggle('endpoint')}>
+              Endpoint
+            </button>
+            <button id={styles.save} onClick={() => handleToggle('hooks')}>
+              Hooks
+            </button>
+            <button id={styles.save} onClick={() => handleToggle('puppeteer')}>
+              Puppeteer
+            </button>
             <button id={styles.save} autoFocus onClick={() => handleToggle('react')}>
               React
             </button>
             <button id={styles.save} onClick={() => handleToggle('redux')}>
               Redux
-            </button>
-            <button id={styles.save} onClick={() => handleToggle('hooks')}>
-              Hooks
-            </button>
-            <button id={styles.save} onClick={() => handleToggle('endpoint')}>
-              Endpoint
-            </button>
-            <button id={styles.save} onClick={() => handleToggle('puppeteer')}>
-              Puppeteer
-            </button>
-            <button id={styles.save} onClick={() => handleToggle('acc')}>
-              Accessibility
             </button>
           </span>
         </div>


### PR DESCRIPTION
![Screenshot from 2021-03-23 11-11-57](https://user-images.githubusercontent.com/75825642/112196882-b6b57f00-8bc8-11eb-8170-8ca2ba50da48.png)  

# Adding React (Enzyme) and Puppeteer Axe-Core Integrations for Accessibility Testing in Spearmint                                           

This pull request covers the integration of React (Enzyme) and Puppeteer tests using the axe-core accessibility engine (i.e., npm package) to further augment the Spearmint accessibility testing suite. These two pieces were added as Accessibility Test Case Actions and related files so that a developer can now choose between testing an html file (i.e., Jest), a React component (i.e., Enzyme), or external URL (i.e., Puppeteer).

Axe is an accessibility testing engine for websites and other HTML-based user interfaces. Integrating Enzyme allows users to test React components with axe-core, whereas Puppeteer allows an end-to-end like experience by running the Axe accessibility engine on an external URL of the developer’s choosing. 

## Changes That Took Place:

* Created React component AccTestTypes to handle selection of HTML, React, or Puppeteer type of accessibility test.
* Updated Modal, modalHooks, AccTestMenu, accTestCaseActions, accTestCaseReducer, and other to manage state based on developer selection of type of accessibility test.
* Implemented ability to dynamically generate  Jest, Enzyme, or Puppeteer test code based on developer’s selection.
* Updated directions included in ‘Run Test’ button selection.
* Added types for state items within new React components.
* Update test menu choices to display in alphabetical order.

## Choose Accessibility Test From Main Menu

<img width="1276" alt="Screen Shot 2021-03-24 at 1 50 09 PM" src="https://user-images.githubusercontent.com/31934392/112382518-30249e80-8ca9-11eb-9d01-78827f5e54c9.png">

Once the developer has chosen ‘Accessibility’ within the Test Menu, he/she/they may choose one of three options from the ‘Choose Type of Accessibility Test’ input: HTML, React (i.e., Enzyme), or Puppeteer. 

This selection will automatically update state, so that upon a selection of the code ‘Preview’ and ‘Run Test’ buttons will show the relevant content based on the type of Accessibility Test selected. See demos below.


# HTML Demo


## HTML Test Code Preview

<img width="1276" alt="Screen Shot 2021-03-24 at 1 50 41 PM" src="https://user-images.githubusercontent.com/31934392/112382896-a88b5f80-8ca9-11eb-9570-c6c61c5139fc.png">

## HTML Test Run Directions

<img width="1274" alt="Screen Shot 2021-03-24 at 1 50 49 PM" src="https://user-images.githubusercontent.com/31934392/112383159-fdc77100-8ca9-11eb-8a4a-a52a24872adc.png">


# React Demo

## React Demo Code Preview

<img width="1276" alt="Screen Shot 2021-03-24 at 1 51 10 PM" src="https://user-images.githubusercontent.com/31934392/112383434-572fa000-8caa-11eb-9125-536cf07ea057.png">

## React Test Run Directions

<img width="670" alt="Screen Shot 2021-03-24 at 1 51 17 PM" src="https://user-images.githubusercontent.com/31934392/112383686-b1306580-8caa-11eb-86fd-3ff189604144.png">

<br>

# Puppeteer Demo

## Puppeteer Demo Code Preview

<img width="1269" alt="Screen Shot 2021-03-24 at 1 51 58 PM" src="https://user-images.githubusercontent.com/31934392/112383776-cb6a4380-8caa-11eb-8a3d-f9f92a53be03.png">

## Puppeteer Test Run Directions

<img width="1275" alt="Screen Shot 2021-03-24 at 1 52 14 PM" src="https://user-images.githubusercontent.com/31934392/112383850-e341c780-8caa-11eb-9e9b-063b441c0b63.png">

<hr>

# Files Created and Modified

```
| src/components/AccTestComponent
    | /AccTestTypes/AccTestTypes.tsx
    | /AccTestTypes/AccTestTypes.module.scss
    | /PuppeteerUrl/PuppeteerUrl.tsx


```
<br>

# Existing Files Modified

```
| src
    | /components
        | /Modals
            | /Modal.jsx
            | /modalHooks.js
        | /SearchInput
            | /SearchInput.scss
        | /TestCase
            | /AccTestCase.tsx
        | /TestMenu
            | /AccTestMenu.tsx
    | /context
        | /actions
            | /accTestCaseActions.ts
        | /reducers
            | /accTestCaseReducer.ts
        | /useGenerateTest.jsx
    | /pages
        | /TestFile/TestFile.jsx
    | /utils
        | /accTypes.ts

```
<br>
<hr>


# Known Bug(s)

<br>
<hr>

# Links to Docs

https://www.deque.com/axe/
https://github.com/dequelabs/axe-core
https://github.com/dequelabs/axe-core/tree/develop/doc/examples
https://www.npmjs.com/package/@axe-core/react
https://www.npmjs.com/package/@axe-core/puppeteer

<hr>

# Contributing Members

Co-authored-by: Annie Shin https://github.com/annieshinn