### PR TITLE
fixed a bug that crashed the app when the first describe block is deleted

### DIFF
--- a/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/ReactTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -47,13 +47,13 @@ const DescribeRenderer = ({
             Describe Block
           </label> */}
 
-          <AiOutlineCloseCircle
+          { i > 0 && <AiOutlineCloseCircle
             tabIndex={0}
             id={id} 
             onKeyPress={deleteReactDescribeBlockOnKeyUp}
             onClick={deleteDescribeBlockHandleClick}
             className={cn('far fa-window-close', styles.describeClose)}
-          />  
+          /> }
           
           {/* <input
             id={id}

--- a/src/components/SolidTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/SolidTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -47,13 +47,13 @@ const DescribeRenderer = ({
             Describe Block
           </label> */}
 
-          <AiOutlineCloseCircle
+          { i > 0 && <AiOutlineCloseCircle
             tabIndex={0}
             id={id} 
             onKeyPress={deleteSolidDescribeBlockOnKeyUp}
             onClick={deleteDescribeBlockHandleClick}
             className={cn('far fa-window-close', styles.describeClose)}
-          />  
+          /> }  
           
           {/* <input
             id={id}

--- a/src/components/SvelteTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/SvelteTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -47,13 +47,13 @@ const DescribeRenderer = ({
             Describe Block
           </label> */}
 
-          <AiOutlineCloseCircle
+          { i > 0 && <AiOutlineCloseCircle
             tabIndex={0}
             id={id} 
             onKeyPress={deleteSvelteDescribeBlockOnKeyUp}
             onClick={deleteDescribeBlockHandleClick}
             className={cn('far fa-window-close', styles.describeClose)}
-          />  
+          /> } 
           
           {/* <input
             id={id}

--- a/src/components/VueTestComponent/DescribeRenderer/DescribeRenderer.jsx
+++ b/src/components/VueTestComponent/DescribeRenderer/DescribeRenderer.jsx
@@ -44,13 +44,13 @@ const DescribeRenderer = ({
           {...provided.dragHandleProps}
         >
 
-          <AiOutlineCloseCircle
+          { i > 0 && <AiOutlineCloseCircle
             tabIndex={0}
             id={id} 
             onKeyPress={deleteVueDescribeBlockOnKeyUp}
             onClick={deleteDescribeBlockHandleClick}
             className={cn('far fa-window-close', styles.describeClose)}
-          /> 
+          /> }
 
           <div className={styles.describeInputContainer}>
             <TextField 


### PR DESCRIPTION
First describe block no longer has the option to delete it. Subsequent blocks still do. 
<img width="875" alt="Screenshot 2022-11-01 at 9 27 08 AM" src="https://user-images.githubusercontent.com/99221170/199287467-766002e6-9ffb-4e4f-a4a2-afb81acff857.png">
