### PR TITLE
Convert Hook components to typescript

### DIFF
--- a/src/components/ReactHooksTestComponent/HookUpdates/HookUpdates.tsx
+++ b/src/components/ReactHooksTestComponent/HookUpdates/HookUpdates.tsx
@@ -11,8 +11,8 @@ import HooksAssertion from '../HooksAssertion';
 import HooksCallback from '../HooksCallback';
 import { GlobalContext } from '../../../context/reducers/globalReducer';
 import { Button } from '@mui/material';
-import { HookUpdatesProps } from '../../../utils/hooksTypes';
-import { Assertion } from '../../../utils/reactTypes';
+import { Callback, HookUpdatesProps } from '../../../utils/hooksTypes';
+import { Assertion } from '../../../utils/hooksTypes';
 
 const closeIcon = require('../../../assets/images/close.png');
 const dragIcon = require('../../../assets/images/drag-vertical.png');
@@ -40,9 +40,9 @@ const HookUpdates = ({ hookUpdates, index }: HookUpdatesProps): JSX.Element => {
     dispatchToHooksTestCase(addCallbackFunc(index));
   };
 
+  // useEffect and useRef used to focus user to the test description field after creating a new hook test
   const testDescription = useRef<HTMLInputElement>(null);
 
-  // useEffect used to focus user to the test description field after creating a new hook test
   useEffect(() => {
     if (testDescription && testDescription.current) {
       testDescription.current.focus();
@@ -107,7 +107,7 @@ const HookUpdates = ({ hookUpdates, index }: HookUpdatesProps): JSX.Element => {
               />
             </div>
           </div>
-          {hookUpdates.callbackFunc.map((callbackFunc: Function, i: number) => {
+          {hookUpdates.callbackFunc.map((callbackFunc: Callback, i: number) => {
             return (
               <div id={styles.cbFlexBox}>
                 <HooksCallback callbackFunc={callbackFunc} index={index} id={i} key={'k' + i} />

--- a/src/components/ReactHooksTestComponent/HooksAssertion.tsx
+++ b/src/components/ReactHooksTestComponent/HooksAssertion.tsx
@@ -5,8 +5,12 @@ import { HooksTestCaseContext } from '../../context/reducers/hooksTestCaseReduce
 import { deleteAssertion, updateAssertion } from '../../context/actions/hooksTestCaseActions';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import { openBrowserDocs } from '../../context/actions/globalActions';
+import { HooksAssertionProps } from '../../utils/hooksTypes';
 
-const HooksAssertion = ({ assertion, index, id }) => {
+type EventTypes = (React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLSelectElement>);
+type FieldTypes = ('expectedState' | 'expectedValue' | 'not' | 'matcher');
+
+const HooksAssertion = ({ assertion, index, id }: HooksAssertionProps): JSX.Element => {
   const [, dispatchToHooksTestCase] = useContext(HooksTestCaseContext);
   const [, dispatchToGlobal] = useContext(GlobalContext);
   const jestDOMMatcher = [
@@ -40,11 +44,11 @@ const HooksAssertion = ({ assertion, index, id }) => {
   const closeIcon = require('../../assets/images/close.png');
   const jestDOMURL = 'https://github.com/testing-library/jest-dom';
 
-  const handleClickDeleteAssertion = () => {
+  const handleClickDeleteAssertion = (): void => {
     dispatchToHooksTestCase(deleteAssertion(index, id));
   };
 
-  const handleChangeUpdateAssertion = (e, field) => {
+  const handleChangeUpdateAssertion = (e: EventTypes, field: FieldTypes): void => {
     const updatedAssertion =
       field === 'not'
         ? { ...assertion, [field]: !assertion[field] }

--- a/src/components/ReactHooksTestComponent/HooksCallback.tsx
+++ b/src/components/ReactHooksTestComponent/HooksCallback.tsx
@@ -2,17 +2,18 @@ import React, { useContext } from 'react';
 import styles from '../EndpointTestComponent/Endpoint.module.scss';
 import { HooksTestCaseContext } from '../../context/reducers/hooksTestCaseReducer';
 import { deleteCallbackFunc, updateCallbackFunc } from '../../context/actions/hooksTestCaseActions';
+import { HooksCallbackProps } from '../../utils/hooksTypes';
 
 const closeIcon = require('../../assets/images/close.png');
 
-const HooksCallback = ({ callbackFunc, index, id }) => {
+const HooksCallback = ({ callbackFunc, index, id }: HooksCallbackProps): JSX.Element => {
   const [, dispatchToHooksTestCase] = useContext(HooksTestCaseContext);
 
-  const handleClickDeleteCallbackFunc = () => {
+  const handleClickDeleteCallbackFunc = (): void => {
     dispatchToHooksTestCase(deleteCallbackFunc(index, id));
   };
 
-  const handleChangeUpdateCallbackFunc = (e, field) => {
+  const handleChangeUpdateCallbackFunc = (e: React.ChangeEvent<HTMLInputElement>, field: 'callbackFunc'): void => {
     const updatedCallbackFunc = { ...callbackFunc, [field]: e.target.value };
     dispatchToHooksTestCase(updateCallbackFunc(index, id, updatedCallbackFunc));
   };

--- a/src/components/TestCase/HooksTestCase.tsx
+++ b/src/components/TestCase/HooksTestCase.tsx
@@ -10,35 +10,39 @@ import {
 import HooksTestMenu from '../TestMenu/HooksTestMenu';
 import HooksTestStatements from './HooksTestStatements';
 import { Button } from '@mui/material';
-import { HooksStatements } from '../../utils/hooksTypes';
+import { Hooks } from '../../utils/hooksTypes';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 import InputTextField from '../InputTextField';
 
-const HooksTestCase = () => {
+const HooksTestCase = (): JSX.Element => {
   
+  // hooksStatements array of of objects of interface Hooks from hooksTestCaseState
   const [{ hooksStatements }, dispatchToHooksTestCase] = useContext(HooksTestCaseContext);
+  // extract theme from GlobalContext
   const [{theme}] = useContext(GlobalContext);
 
-
-  const handleUpdateHooksTestStatement = (e: React.ChangeEvent<HTMLInputElement>) => {
+  // handle text input in Describe Block input field
+  const handleUpdateHooksTestStatement = (e: React.ChangeEvent<HTMLInputElement>): void => {
     dispatchToHooksTestCase(updateHooksTestStatement(e.target.value));
   };
 
-  const reorder = (list: Array<HooksStatements>, startIndex: number, endIndex: number) => {
+  // reorder array of Hooks
+  const reorder = (list: Hooks[], startIndex: number, endIndex: number): Hooks[] => {
     const result = Array.from(list);
     const [removed] = result.splice(startIndex, 1);
     result.splice(endIndex, 0, removed);
     return result;
   };
 
-  const onDragEnd = (result:typeof DropResult) => {
+  // after dropping draggable, update state with reorderd list of Hooks
+  const onDragEnd = (result:typeof DropResult): void => {
     if (!result.destination) {
       return;
     }
     if (result.destination.index === result.source.index) {
       return;
     }
-    const reorderedStatements: Array<HooksStatements> = reorder(
+    const reorderedStatements: Array<Hooks> = reorder(
       hooksStatements,
       result.source.index,
       result.destination.index
@@ -46,9 +50,11 @@ const HooksTestCase = () => {
     dispatchToHooksTestCase(updateStatementsOrder(reorderedStatements));
   };
 
-  const handleAddHookUpdates = () => {
+  // create new Hook
+  const handleAddHookUpdates = (): void => {
     dispatchToHooksTestCase(addHookUpdates());
   };
+
   return (
     <>
       <div id='head'>

--- a/src/components/TestCase/HooksTestStatements.tsx
+++ b/src/components/TestCase/HooksTestStatements.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import HookUpdates from '../ReactHooksTestComponent/HookUpdates/HookUpdates';
 import { HooksTestCaseContext } from '../../context/reducers/hooksTestCaseReducer';
-import { HooksStatements } from '../../utils/hooksTypes';
+import { Hooks } from '../../utils/hooksTypes';
 import importOptionsSwitch from './importOptions';
 import SearchInput from '../SearchInput/SearchInput';
 import { updateHooksFilePath } from '../../context/actions/hooksTestCaseActions';
@@ -9,10 +9,11 @@ import styles from '../../components/TestCase/TestCase.module.scss';
 import { GlobalContext } from '../../context/reducers/globalReducer';
 
 
-const HooksTestStatements = () => {
+const HooksTestStatements = (): JSX.Element => {
+  // hooksStatements is an array of objects of interface Hooks from hooksTestCaseState
   const [{ hooksStatements }, dispatchToHooksTestCase] = useContext(HooksTestCaseContext);
   const { isHooksOn } = importOptionsSwitch(hooksStatements);
-  const [{ filePathMap, theme }] = useContext<any>(GlobalContext);
+  const [{ filePathMap, theme }] = useContext(GlobalContext);
 
   let hImports = null;
   if (isHooksOn) {
@@ -31,7 +32,7 @@ const HooksTestStatements = () => {
   return (
     <>
       {hImports}
-      {hooksStatements.map((statement: HooksStatements, i: number) => {
+      {hooksStatements.map((statement: Hooks, i: number) => {
         switch (statement.type) {
           case 'hooks':
             return <HookUpdates key={statement.id} hookUpdates={statement} index={i} />;

--- a/src/context/actions/hooksTestCaseActions.ts
+++ b/src/context/actions/hooksTestCaseActions.ts
@@ -1,4 +1,4 @@
-import { HooksStatements } from '../../utils/hooksTypes';
+import { Assertion, Callback, Hooks } from '../../utils/hooksTypes';
 
 export const actionTypes = {
   TOGGLE_HOOKS: 'TOGGLE_HOOKS',
@@ -44,7 +44,7 @@ export const deleteHookUpdates = (id: number) => ({
   id,
 });
 
-export const updateHookUpdates = (hooksUpdates: object) => ({
+export const updateHookUpdates = (hooksUpdates: Hooks) => ({
   ...hooksUpdates,
   type: actionTypes.UPDATE_HOOK_UPDATES,
 });
@@ -59,7 +59,7 @@ export const createNewHooksTest = () => ({
   type: actionTypes.CREATE_NEW_HOOKS_TEST,
 });
 
-export const updateStatementsOrder = (draggableStatements: Array<HooksStatements>) => ({
+export const updateStatementsOrder = (draggableStatements: Hooks[]) => ({
   type: actionTypes.UPDATE_STATEMENTS_ORDER,
   draggableStatements,
 });

--- a/src/context/reducers/hooksTestCaseReducer.ts
+++ b/src/context/reducers/hooksTestCaseReducer.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react';
-import { HooksTestCaseState, Assertion, Action, Hooks, Callback } from '../../utils/hooksTypes';
+import { actionTypes } from '../actions/hooksTestCaseActions';
+import { HooksTestCaseState, Assertion, Action, Hooks, Callback, HooksAction } from '../../utils/hooksTypes';
 
 const newAssertion: Assertion = {
   id: 0,
@@ -63,7 +64,7 @@ export const hooksTestCaseState: HooksTestCaseState = {
   hookFilePath: '',
 };
 
-const deepCopy = (hooksStatements: Hooks[]) => {
+const deepCopy = (hooksStatements: Hooks[]): Hooks[] => {
   function copyAssertions(array: Assertion[]) {
     const copy: Assertion[] = array.map((el) => {
       return { ...el };
@@ -89,24 +90,26 @@ const deepCopy = (hooksStatements: Hooks[]) => {
   return fullCopy;
 };
 
-export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAction) => {
+// used to be
+// export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAction) => {
+export const hooksTestCaseReducer = (state: HooksTestCaseState, action: Action) => {
   Object.freeze(state);
-  let hooksStatements = [...state.hooksStatements];
+  let hooksStatements: Hooks[] = [...state.hooksStatements];
 
   switch (action.type) {
     
-    case 'RESET_TESTS': {
+    case actionTypes.RESET_TESTS: {
       return hooksTestCaseState;
     }
   
-    case 'UPDATE_HOOKS_TEST_STATEMENT': {
+    case actionTypes.UPDATE_HOOKS_TEST_STATEMENT: {
       return {
         ...state,
         hooksTestStatement: action.hooksTestStatement,
       };
     }
 
-    case 'ADD_CONTEXT':
+    case actionTypes.ADD_CONTEXT: {
       if (hooksStatements.length === 0) {
         return {
           ...state,
@@ -123,37 +126,42 @@ export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAct
         ...state,
         hooksStatements,
       };
-    case 'DELETE_CONTEXT':
+    }
+
+    case actionTypes.DELETE_CONTEXT: {
       hooksStatements = hooksStatements.filter((statement) => statement.id !== action.id);
       return {
         ...state,
         hooksStatements,
       };
+    }
 
-    case 'UPDATE_CONTEXT':
-      hooksStatements = hooksStatements.map((statement) => {
-        if (statement.id === action.id) {
-          return {
-            ...statement,
-            queryVariant: action.queryVariant,
-            querySelector: action.querySelector,
-            queryValue: action.queryValue,
-            values: action.values,
-            textNode: action.textNodes,
-            testName: action.testName,
-            providerComponent: action.providerComponent,
-            consumerComponent: action.consumerComponent,
-            context: action.context,
-          };
-        }
-        return statement;
-      });
-      return {
-        ...state,
-        hooksStatements,
-      };
+    // >>>>>>>>> CURRENTLY NOT USED <<<<<<<<
+    // case actionTypes.UPDATE_CONTEXT: {
+    //   hooksStatements = hooksStatements.map((statement) => {
+    //     if (statement.id === action.id) {
+    //       return {
+    //         ...statement,
+    //         queryVariant: action.queryVariant,
+    //         querySelector: action.querySelector,
+    //         queryValue: action.queryValue,
+    //         values: action.values,
+    //         textNode: action.textNodes,
+    //         testName: action.testName,
+    //         providerComponent: action.providerComponent,
+    //         consumerComponent: action.consumerComponent,
+    //         context: action.context,
+    //       };
+    //     }
+    //     return statement;
+    //   });
+    //   return {
+    //     ...state,
+    //     hooksStatements,
+    //   };
+    // }
 
-    case 'ADD_HOOK_UPDATES':
+    case actionTypes.ADD_HOOK_UPDATES: {
       if (hooksStatements.length === 0) {
         return {
           ...state,
@@ -171,26 +179,32 @@ export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAct
         ...state,
         hooksStatements,
       };
+    }
 
-    case 'DELETE_HOOK_UPDATES':
+    case actionTypes.DELETE_HOOK_UPDATES: {
       hooksStatements = hooksStatements.filter((statement) => statement.id !== action.id);
       return {
         ...state,
         hooksStatements,
       };
+    }
 
-    case 'UPDATE_HOOK_UPDATES':
+    case actionTypes.UPDATE_HOOK_UPDATES: {
       let newStatement = hooksStatements.find((statement) => {
         return statement.id === action.id;
       });
-      Object.assign(newStatement, action, {
-        type: 'hooks',
-      });
+      if (newStatement !== undefined) {
+        Object.assign(newStatement, action, {
+          type: 'hooks',
+        });
+      }
       return {
         ...state,
         hooksStatements,
       };
-    case 'UPDATE_HOOKS_FILEPATH':
+    }
+
+    case actionTypes.UPDATE_HOOKS_FILEPATH: {
       hooksStatements = hooksStatements.map((statement) => {
         return {
           ...statement,
@@ -202,7 +216,9 @@ export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAct
         ...state,
         hooksStatements,
       };
-    case 'UPDATE_CONTEXT_FILEPATH':
+    }
+
+    case actionTypes.UPDATE_CONTEXT_FILEPATH: {
       hooksStatements = hooksStatements.map((statement) => {
         if (statement.type === 'context') {
           return {
@@ -217,32 +233,41 @@ export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAct
         ...state,
         hooksStatements,
       };
+    }
 
-    case 'CREATE_NEW_HOOKS_TEST':
+    case actionTypes.CREATE_NEW_HOOKS_TEST: {
       return {
         modalOpen: false,
         hooksTestStatement: '',
         hooksStatements: [{ ...newHooks, assertions: [{ ...newAssertion }] }],
       };
-    case 'UPDATE_STATEMENTS_ORDER': {
-      const newHooksStatements = [...action.draggableStatements];
-      return {
-        ...state,
-        hooksStatements: newHooksStatements,
-      };
     }
-    case 'OPEN_INFO_MODAL':
+
+    case actionTypes.UPDATE_STATEMENTS_ORDER: {
+      if (action.draggableStatements) {
+        const newHooksStatements = [...action.draggableStatements];
+        return {
+          ...state,
+          hooksStatements: newHooksStatements,
+        };
+      }
+    }
+
+    case actionTypes.OPEN_INFO_MODAL: {
       return {
         ...state,
         modalOpen: true,
       };
-    case 'CLOSE_INFO_MODAL':
+    }
+
+    case actionTypes.CLOSE_INFO_MODAL: {
       return {
         ...state,
         modalOpen: false,
       };
+    }
 
-    case 'ADD_ASSERTION':
+    case actionTypes.ADD_ASSERTION: {
       hooksStatements[action.index as number].assertions.push({
         id: hooksStatements[hooksStatements.length - 1].id + 1,
         expectedState: '',
@@ -254,20 +279,25 @@ export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAct
         ...state,
         hooksStatements: deepCopy(hooksStatements),
       };
-    case 'DELETE_ASSERTION':
+    }
+
+    case actionTypes.DELETE_ASSERTION: {
       hooksStatements[action.index as number].assertions.splice(action.id!, 1);
       return {
         ...state,
         hooksStatements: deepCopy(hooksStatements),
       };
-    case 'UPDATE_ASSERTION':
+    }
+
+    case actionTypes.UPDATE_ASSERTION: {
       hooksStatements[action.index as number].assertions[action.id as number] = action.assertion!;
       return {
         ...state,
         hooksStatements: deepCopy(hooksStatements),
       };
+    }
 
-    case 'ADD_CALLBACKFUNC':
+    case actionTypes.ADD_CALLBACKFUNC: {
       hooksStatements[action.index as number].callbackFunc.push({
         id: hooksStatements[hooksStatements.length - 1].id + 1,
         callbackFunc: '',
@@ -276,29 +306,39 @@ export const hooksTestCaseReducer = (state: HooksTestCaseState, action: HooksAct
         ...state,
         hooksStatements: deepCopy(hooksStatements),
       };
-    case 'DELETE_CALLBACKFUNC':
+    }
+
+    case actionTypes.DELETE_CALLBACKFUNC: {
       hooksStatements[action.index as number].callbackFunc.splice(action.id!, 1);
       return {
         ...state,
         hooksStatements: deepCopy(hooksStatements),
       };
-    case 'UPDATE_CALLBACKFUNC':
+    }
+
+    case actionTypes.UPDATE_CALLBACKFUNC: {
       hooksStatements[action.index as number].callbackFunc[
         action.id as number
-      ] = action.callbackFunc!;
+      ] = action.callback!;
       return {
         ...state,
         hooksStatements: deepCopy(hooksStatements),
       };
-    case 'TOGGLE_TYPEOF':
-      hooksStatements[action.index as number].post = !hooksStatements[action.index as number].post;
-      return {
-        ...state,
-        hooksStatements,
-      };
-    case 'REPLACE_TEST': {
+    }
+
+    // >>>>>>>>> CURRENTLY NOT USED <<<<<<<<
+    // case actionTypes.TOGGLE_TYPEOF: {
+    //   hooksStatements[action.index as number].post = !hooksStatements[action.index as number].post;
+    //   return {
+    //     ...state,
+    //     hooksStatements,
+    //   };
+    // }
+
+    case actionTypes.REPLACE_TEST: {
       return action.testState;
     }
+
     default:
       return state;
   }

--- a/src/utils/hooksTypes.ts
+++ b/src/utils/hooksTypes.ts
@@ -1,8 +1,8 @@
-export interface HooksStatements {
-  id: number;
-  type: string;
-  [key: string]: any;
-}
+// export interface HooksStatements {
+//   id: number;
+//   type: string;
+//   [key: string]: any;
+// }
 
 export interface HooksTestCaseState {
   hookFileName: string;
@@ -14,10 +14,10 @@ export interface HooksTestCaseState {
 
 export interface Assertion {
   id: number;
-  expectedState: string;
-  matcher: string;
-  expectedValue: string;
-  not: boolean;
+  expectedState?: string;
+  matcher?: string;
+  expectedValue?: string;
+  not?: boolean;
 }
 
 export interface Callback {
@@ -34,8 +34,8 @@ export interface Hooks {
   assertions: Assertion[];
   callbackFunc: Callback[];
   typeof: boolean;
-  hookFileName: string;
-  hookFilePath: string;
+  hookFileName?: string;
+  hookFilePath?: string;
 }
 
 export interface Action {
@@ -43,7 +43,7 @@ export interface Action {
   id?: number;
   serverFileName?: string;
   serverFilePath?: string;
-  draggableStatements?: Array<HooksStatements>;
+  draggableStatements?: Hooks[];
   index?: number;
   text?: string;
   assertion?: Assertion;
@@ -51,16 +51,34 @@ export interface Action {
   dbFilePath?: string;
   dbFileName?: string;
   testState?: object;
+  hooksTestStatement?: string;
+  hookFileName?: string;
+  hookFilePath?: string;
+  contextFileName?: string;
+  contextFilePath?: string;
+  callback?: Callback;
 }
 
 export interface HookUpdatesProps {
-  hookUpdates: HooksStatements,
-  index: number
+  hookUpdates: Hooks;
+  index: number;
+}
+
+export interface HooksAssertionProps {
+  assertion: Assertion;
+  index: number;
+  id: number;
+}
+
+export interface HooksCallbackProps {
+  callbackFunc: Callback;
+  index: number;
+  id: number;
 }
 
 /* ---------------------------- Actions In Reducer coming from hooksTestCaseActions ---------------------- */
 
-export type HooksAction =
+export type HooksAction = 
   | {
       type:
         | 'TOGGLE_HOOKS'
@@ -120,5 +138,5 @@ export interface HooksTestModalProps {
 }
 
 export interface HooksTestStatementsProps extends HooksTestMenuProps {
-  hooksStatements: Array<HooksStatements>;
+  hooksStatements: Hooks[];
 }


### PR DESCRIPTION
Converted HooksAssertion and HooksCallback components to typescript as well as finished converting other files related to Hook components.